### PR TITLE
[E1] Typed Phase State Machine

### DIFF
--- a/agent_state_machine.py
+++ b/agent_state_machine.py
@@ -1,13 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Typed finite state machine for the OpenSIN HeyPiggy worker.
+
+WHY THIS MODULE EXISTS:
+- The worker used to move through a mostly linear script with ad-hoc branching.
+- That shape makes it hard to prove which phase the worker is currently in.
+- It also makes fail-safe handling, escalation, and checkpointing inconsistent.
+
+WHAT THIS MODULE PROVIDES:
+- A strongly typed `AgentState` enum for every major worker phase.
+- A `StepContext` dataclass that carries the live FSM metadata.
+- A strict transition table that blocks invalid state jumps.
+- Shared fail-safe and escalation helpers that always checkpoint context.
+
+CONSEQUENCES:
+- The worker can now reason about its own phase explicitly.
+- Invalid phase jumps fail loudly instead of silently corrupting control flow.
+- Debugging and recovery become easier because every transition is logged as JSON.
+"""
+
+from __future__ import annotations
+
 import enum
 import json
-import uuid
 import sys
-from dataclasses import dataclass, field
+import uuid
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Final
+
+
+# WHY: A stable checkpoint filename makes it trivial for operators, tests, and
+# recovery tooling to know where the latest context snapshot will be written.
+CHECKPOINT_PATH: Final[Path] = Path("checkpoint.json")
+
 
 class AgentState(enum.Enum):
+    """
+    Typed list of all allowed high-level worker phases.
+
+    WHY THIS ENUM EXISTS:
+    - Stringly typed phases are easy to mistype and hard to validate.
+    - An enum gives us one canonical vocabulary for orchestration, tests,
+      structured logging, and future recovery tooling.
+
+    CONSEQUENCES:
+    - Every transition is explicit and machine-checkable.
+    - Tests can assert exact states instead of brittle free-form strings.
+    """
+
     INIT = "INIT"
     PREFLIGHT = "PREFLIGHT"
     ACQUIRE_SESSION = "ACQUIRE_SESSION"
@@ -25,125 +68,302 @@ class AgentState(enum.Enum):
     FAIL_SAFE = "FAIL_SAFE"
     ESCALATE = "ESCALATE"
 
+
 class IllegalTransitionError(Exception):
-    pass
+    """
+    Raised when the caller attempts a state jump not permitted by the FSM.
+
+    WHY THIS CUSTOM EXCEPTION EXISTS:
+    - A domain-specific exception makes illegal control-flow bugs obvious.
+    - Catchers can distinguish FSM violations from unrelated runtime failures.
+    """
+
 
 @dataclass
 class StepContext:
-    state: AgentState = AgentState.INIT
-    step_index: int = 0
+    """
+    Runtime context that travels together with the worker FSM.
+
+    WHY THESE FIELDS EXIST:
+    - `state` tells us the current phase.
+    - `step_index` counts successful transitions so operators can reason about
+      progress and loop length.
+    - `max_steps` gives the controller a hard safety ceiling.
+    - `no_progress_counter` tracks repeated iterations with no visible progress.
+    - `last_page_fingerprint` lets the worker compare current vs previous page.
+    - `run_id` provides a globally unique execution identifier.
+    - `task_url` remembers which survey/task is currently being processed.
+    - `earnings_so_far` stores accumulated outcome value for reporting.
+
+    CONSEQUENCES:
+    - The worker can checkpoint enough data to recover or debug meaningfully.
+    - Tests can build minimal contexts while still exercising real behavior.
+    """
+
+    state: AgentState
+    step_index: int
     max_steps: int = 120
     no_progress_counter: int = 0
     last_page_fingerprint: str = ""
     run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    task_url: Optional[str] = None
+    task_url: str | None = None
     earnings_so_far: float = 0.0
 
-# Transition table defining valid next states per state
-TRANSITIONS: Dict[AgentState, List[AgentState]] = {
-    AgentState.INIT: [AgentState.PREFLIGHT, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.PREFLIGHT: [AgentState.ACQUIRE_SESSION, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.ACQUIRE_SESSION: [AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+
+# WHY: Keeping the transition table as module-level data makes the legal phase
+# graph visible, testable, and reusable from multiple worker entry points.
+TRANSITION_TABLE: dict[AgentState, list[AgentState]] = {
+    AgentState.INIT: [
+        AgentState.PREFLIGHT,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.PREFLIGHT: [
+        AgentState.ACQUIRE_SESSION,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.ACQUIRE_SESSION: [
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
     AgentState.ASSESS_PAGE: [
-        AgentState.RESOLVE_BLOCKERS, AgentState.AUTHENTICATE, AgentState.ONBOARD,
-        AgentState.DISCOVER_WORK, AgentState.EXECUTE_TASK_LOOP, AgentState.FAIL_SAFE, AgentState.ESCALATE
+        AgentState.RESOLVE_BLOCKERS,
+        AgentState.AUTHENTICATE,
+        AgentState.ONBOARD,
+        AgentState.DISCOVER_WORK,
+        AgentState.SELECT_TASK,
+        AgentState.ENTER_TASK,
+        AgentState.EXECUTE_TASK_LOOP,
+        AgentState.VALIDATE_OUTCOME,
+        AgentState.RECORD_RESULT,
+        AgentState.COMPLETE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
     ],
-    AgentState.RESOLVE_BLOCKERS: [AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.AUTHENTICATE: [AgentState.ONBOARD, AgentState.DISCOVER_WORK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.ONBOARD: [AgentState.DISCOVER_WORK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.DISCOVER_WORK: [AgentState.SELECT_TASK, AgentState.ASSESS_PAGE, AgentState.COMPLETE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.SELECT_TASK: [AgentState.ENTER_TASK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.ENTER_TASK: [AgentState.EXECUTE_TASK_LOOP, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.RESOLVE_BLOCKERS: [
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.AUTHENTICATE: [
+        AgentState.ONBOARD,
+        AgentState.DISCOVER_WORK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.ONBOARD: [
+        AgentState.DISCOVER_WORK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.DISCOVER_WORK: [
+        AgentState.SELECT_TASK,
+        AgentState.COMPLETE,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.SELECT_TASK: [
+        AgentState.ENTER_TASK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.ENTER_TASK: [
+        AgentState.EXECUTE_TASK_LOOP,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
     AgentState.EXECUTE_TASK_LOOP: [
-        AgentState.VALIDATE_OUTCOME, AgentState.EXECUTE_TASK_LOOP,
-        AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE
+        AgentState.EXECUTE_TASK_LOOP,
+        AgentState.VALIDATE_OUTCOME,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
     ],
-    AgentState.VALIDATE_OUTCOME: [AgentState.RECORD_RESULT, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.RECORD_RESULT: [AgentState.COMPLETE, AgentState.DISCOVER_WORK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
-    AgentState.COMPLETE: [AgentState.FAIL_SAFE, AgentState.ESCALATE], # Terminal unless escalated
-    AgentState.FAIL_SAFE: [AgentState.ESCALATE], # Terminal, only escalation possible
-    AgentState.ESCALATE: [] # Terminal
+    AgentState.VALIDATE_OUTCOME: [
+        AgentState.RECORD_RESULT,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.RECORD_RESULT: [
+        AgentState.COMPLETE,
+        AgentState.DISCOVER_WORK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.COMPLETE: [
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.FAIL_SAFE: [
+        AgentState.ESCALATE,
+    ],
+    AgentState.ESCALATE: [],
 }
 
-def step_context_advance(ctx: StepContext, new_state: AgentState, reason: str) -> None:
+
+def _context_to_json_dict(ctx: StepContext) -> dict[str, object]:
     """
-    Validates transition, logs to structured JSON, raises IllegalTransitionError if invalid.
+    Convert the dataclass into JSON-safe primitives.
+
+    WHY THIS HELPER EXISTS:
+    - `asdict()` keeps the conversion logic centralized.
+    - The enum must be serialized as its readable name instead of a Python object.
+
+    CONSEQUENCES:
+    - Checkpoints and logs become deterministic and easy to inspect.
     """
-    allowed_next = TRANSITIONS.get(ctx.state, [])
-    if new_state not in allowed_next:
-        raise IllegalTransitionError(f"Cannot transition from {ctx.state.name} to {new_state.name}")
-    
-    # Log the state change
+
+    payload = asdict(ctx)
+    payload["state"] = ctx.state.name
+    return payload
+
+
+def _write_checkpoint(ctx: StepContext, reason: str, exception: Exception | None = None) -> Path:
+    """
+    Persist the current FSM context to `checkpoint.json`.
+
+    WHY THIS HELPER EXISTS:
+    - Both fail-safe and escalation must checkpoint identically.
+    - Centralizing the write logic avoids drift between the two exit paths.
+
+    CONSEQUENCES:
+    - Operators can always inspect one canonical recovery file.
+    """
+
+    checkpoint_payload = {
+        **_context_to_json_dict(ctx),
+        "reason": reason,
+        "exception": repr(exception) if exception is not None else None,
+        "checkpoint_timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    CHECKPOINT_PATH.write_text(
+        json.dumps(checkpoint_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return CHECKPOINT_PATH
+
+
+def _log_transition(ctx: StepContext, previous_state: AgentState, new_state: AgentState, reason: str) -> None:
+    """
+    Emit one structured JSON log entry for a successful transition.
+
+    WHY THIS HELPER EXISTS:
+    - Transition logging must be consistent across all callers.
+    - JSON logs are easier to ingest into audit tooling than free-form text.
+
+    CONSEQUENCES:
+    - Every accepted state change can be correlated by `run_id` and step index.
+    """
+
     log_entry = {
+        "event": "state_transition",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "run_id": ctx.run_id,
-        "from_state": ctx.state.name,
+        "step_index": ctx.step_index,
+        "from_state": previous_state.name,
         "to_state": new_state.name,
         "reason": reason,
-        "step_index": ctx.step_index
+        "task_url": ctx.task_url,
+        "no_progress_counter": ctx.no_progress_counter,
+        "earnings_so_far": ctx.earnings_so_far,
     }
-    print(f"[STATE MACHINE] {json.dumps(log_entry)}")
-    
+    print(json.dumps(log_entry, ensure_ascii=False))
+
+
+def step_context_advance(ctx: StepContext, new_state: AgentState, reason: str) -> StepContext:
+    """
+    Validate and perform one FSM transition.
+
+    WHY THIS FUNCTION EXISTS:
+    - Callers should never mutate `ctx.state` directly because that bypasses the
+      legal transition rules and destroys our audit trail.
+    - This helper is the single gatekeeper for all normal phase changes.
+
+    CONSEQUENCES:
+    - Illegal transitions raise `IllegalTransitionError` immediately.
+    - Successful transitions increment the step index and emit structured JSON.
+    """
+
+    previous_state = ctx.state
+    allowed_next_states = TRANSITION_TABLE.get(previous_state, [])
+    if new_state not in allowed_next_states:
+        allowed_names = [state.name for state in allowed_next_states]
+        raise IllegalTransitionError(
+            f"Illegal transition {previous_state.name} -> {new_state.name}. "
+            f"Allowed: {allowed_names}"
+        )
+
+    _log_transition(ctx, previous_state, new_state, reason)
     ctx.state = new_state
     ctx.step_index += 1
+    return ctx
+
 
 def fail_safe(ctx: StepContext, reason: str) -> None:
     """
-    Log reason, save ctx to checkpoint.json, print summary, exit cleanly.
+    Enter the fail-safe terminal path, checkpoint context, and exit cleanly.
+
+    WHY THIS FUNCTION EXISTS:
+    - Some situations are recoverable enough that we want a controlled stop
+      instead of a hard crash.
+    - We still need a checkpoint and a clear human-readable summary.
+
+    CONSEQUENCES:
+    - The process exits with code `0` after persisting the latest context.
+    - If the caller was not already in `FAIL_SAFE`, we try to advance into it.
     """
-    print(f"[FAIL_SAFE] {reason}")
-    try:
+
+    if ctx.state != AgentState.FAIL_SAFE:
         step_context_advance(ctx, AgentState.FAIL_SAFE, reason)
-    except IllegalTransitionError:
-        ctx.state = AgentState.FAIL_SAFE
-    
-    checkpoint_file = Path(f"/tmp/heypiggy_run_{ctx.run_id}_checkpoint.json")
-    try:
-        with open(checkpoint_file, "w") as f:
-            json.dump({
-                "state": ctx.state.name,
-                "step_index": ctx.step_index,
-                "max_steps": ctx.max_steps,
-                "no_progress_counter": ctx.no_progress_counter,
-                "last_page_fingerprint": ctx.last_page_fingerprint,
-                "run_id": ctx.run_id,
-                "task_url": ctx.task_url,
-                "earnings_so_far": ctx.earnings_so_far,
-                "reason": reason
-            }, f, indent=2)
-        print(f"[FAIL_SAFE] Context saved to {checkpoint_file}")
-    except Exception as e:
-        print(f"[FAIL_SAFE] Failed to write checkpoint: {e}")
-        
-    print(f"[FAIL_SAFE] Exiting cleanly.")
-    sys.exit(0)
 
-def escalate(ctx: StepContext, reason: str, exception: Optional[Exception] = None) -> None:
+    checkpoint_path = _write_checkpoint(ctx, reason)
+    summary = {
+        "event": "fail_safe",
+        "run_id": ctx.run_id,
+        "state": ctx.state.name,
+        "step_index": ctx.step_index,
+        "reason": reason,
+        "checkpoint": str(checkpoint_path),
+    }
+    print(json.dumps(summary, ensure_ascii=False))
+    raise SystemExit(0)
+
+
+def escalate(ctx: StepContext, reason: str, exception: Exception | None = None) -> None:
     """
-    Same as fail_safe but also prints ESCALATE to stderr, exit 1.
+    Enter the escalation terminal path, checkpoint context, and exit with error.
+
+    WHY THIS FUNCTION EXISTS:
+    - Retry exhaustion or unrecoverable contradictions must be surfaced loudly.
+    - Operators need both stderr visibility and an on-disk checkpoint snapshot.
+
+    CONSEQUENCES:
+    - The process exits with code `1` after printing `ESCALATE` to stderr.
+    - The optional exception is preserved in the checkpoint for later debugging.
     """
-    print(f"[ESCALATE] {reason}", file=sys.stderr)
-    if exception:
-        print(f"[ESCALATE] Exception: {exception}", file=sys.stderr)
-        
-    try:
+
+    if ctx.state != AgentState.ESCALATE:
         step_context_advance(ctx, AgentState.ESCALATE, reason)
-    except IllegalTransitionError:
-        ctx.state = AgentState.ESCALATE
-        
-    checkpoint_file = Path(f"/tmp/heypiggy_run_{ctx.run_id}_checkpoint.json")
-    try:
-        with open(checkpoint_file, "w") as f:
-            json.dump({
-                "state": ctx.state.name,
-                "step_index": ctx.step_index,
-                "run_id": ctx.run_id,
-                "reason": reason,
-                "exception": str(exception) if exception else None
-            }, f, indent=2)
-    except Exception:
-        pass
-        
-    print(f"[ESCALATE] Exiting with error.", file=sys.stderr)
-    sys.exit(1)
 
+    checkpoint_path = _write_checkpoint(ctx, reason, exception=exception)
+    escalation_summary = {
+        "event": "escalate",
+        "run_id": ctx.run_id,
+        "state": ctx.state.name,
+        "step_index": ctx.step_index,
+        "reason": reason,
+        "exception": repr(exception) if exception is not None else None,
+        "checkpoint": str(checkpoint_path),
+    }
+    print("ESCALATE", file=sys.stderr)
+    print(json.dumps(escalation_summary, ensure_ascii=False), file=sys.stderr)
+    raise SystemExit(1)

--- a/agent_state_machine.py
+++ b/agent_state_machine.py
@@ -1,0 +1,149 @@
+import enum
+import json
+import uuid
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+class AgentState(enum.Enum):
+    INIT = "INIT"
+    PREFLIGHT = "PREFLIGHT"
+    ACQUIRE_SESSION = "ACQUIRE_SESSION"
+    ASSESS_PAGE = "ASSESS_PAGE"
+    RESOLVE_BLOCKERS = "RESOLVE_BLOCKERS"
+    AUTHENTICATE = "AUTHENTICATE"
+    ONBOARD = "ONBOARD"
+    DISCOVER_WORK = "DISCOVER_WORK"
+    SELECT_TASK = "SELECT_TASK"
+    ENTER_TASK = "ENTER_TASK"
+    EXECUTE_TASK_LOOP = "EXECUTE_TASK_LOOP"
+    VALIDATE_OUTCOME = "VALIDATE_OUTCOME"
+    RECORD_RESULT = "RECORD_RESULT"
+    COMPLETE = "COMPLETE"
+    FAIL_SAFE = "FAIL_SAFE"
+    ESCALATE = "ESCALATE"
+
+class IllegalTransitionError(Exception):
+    pass
+
+@dataclass
+class StepContext:
+    state: AgentState = AgentState.INIT
+    step_index: int = 0
+    max_steps: int = 120
+    no_progress_counter: int = 0
+    last_page_fingerprint: str = ""
+    run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    task_url: Optional[str] = None
+    earnings_so_far: float = 0.0
+
+# Transition table defining valid next states per state
+TRANSITIONS: Dict[AgentState, List[AgentState]] = {
+    AgentState.INIT: [AgentState.PREFLIGHT, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.PREFLIGHT: [AgentState.ACQUIRE_SESSION, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.ACQUIRE_SESSION: [AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.ASSESS_PAGE: [
+        AgentState.RESOLVE_BLOCKERS, AgentState.AUTHENTICATE, AgentState.ONBOARD,
+        AgentState.DISCOVER_WORK, AgentState.EXECUTE_TASK_LOOP, AgentState.FAIL_SAFE, AgentState.ESCALATE
+    ],
+    AgentState.RESOLVE_BLOCKERS: [AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.AUTHENTICATE: [AgentState.ONBOARD, AgentState.DISCOVER_WORK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.ONBOARD: [AgentState.DISCOVER_WORK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.DISCOVER_WORK: [AgentState.SELECT_TASK, AgentState.ASSESS_PAGE, AgentState.COMPLETE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.SELECT_TASK: [AgentState.ENTER_TASK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.ENTER_TASK: [AgentState.EXECUTE_TASK_LOOP, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.EXECUTE_TASK_LOOP: [
+        AgentState.VALIDATE_OUTCOME, AgentState.EXECUTE_TASK_LOOP,
+        AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE
+    ],
+    AgentState.VALIDATE_OUTCOME: [AgentState.RECORD_RESULT, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.RECORD_RESULT: [AgentState.COMPLETE, AgentState.DISCOVER_WORK, AgentState.ASSESS_PAGE, AgentState.FAIL_SAFE, AgentState.ESCALATE],
+    AgentState.COMPLETE: [AgentState.FAIL_SAFE, AgentState.ESCALATE], # Terminal unless escalated
+    AgentState.FAIL_SAFE: [AgentState.ESCALATE], # Terminal, only escalation possible
+    AgentState.ESCALATE: [] # Terminal
+}
+
+def step_context_advance(ctx: StepContext, new_state: AgentState, reason: str) -> None:
+    """
+    Validates transition, logs to structured JSON, raises IllegalTransitionError if invalid.
+    """
+    allowed_next = TRANSITIONS.get(ctx.state, [])
+    if new_state not in allowed_next:
+        raise IllegalTransitionError(f"Cannot transition from {ctx.state.name} to {new_state.name}")
+    
+    # Log the state change
+    log_entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "run_id": ctx.run_id,
+        "from_state": ctx.state.name,
+        "to_state": new_state.name,
+        "reason": reason,
+        "step_index": ctx.step_index
+    }
+    print(f"[STATE MACHINE] {json.dumps(log_entry)}")
+    
+    ctx.state = new_state
+    ctx.step_index += 1
+
+def fail_safe(ctx: StepContext, reason: str) -> None:
+    """
+    Log reason, save ctx to checkpoint.json, print summary, exit cleanly.
+    """
+    print(f"[FAIL_SAFE] {reason}")
+    try:
+        step_context_advance(ctx, AgentState.FAIL_SAFE, reason)
+    except IllegalTransitionError:
+        ctx.state = AgentState.FAIL_SAFE
+    
+    checkpoint_file = Path(f"/tmp/heypiggy_run_{ctx.run_id}_checkpoint.json")
+    try:
+        with open(checkpoint_file, "w") as f:
+            json.dump({
+                "state": ctx.state.name,
+                "step_index": ctx.step_index,
+                "max_steps": ctx.max_steps,
+                "no_progress_counter": ctx.no_progress_counter,
+                "last_page_fingerprint": ctx.last_page_fingerprint,
+                "run_id": ctx.run_id,
+                "task_url": ctx.task_url,
+                "earnings_so_far": ctx.earnings_so_far,
+                "reason": reason
+            }, f, indent=2)
+        print(f"[FAIL_SAFE] Context saved to {checkpoint_file}")
+    except Exception as e:
+        print(f"[FAIL_SAFE] Failed to write checkpoint: {e}")
+        
+    print(f"[FAIL_SAFE] Exiting cleanly.")
+    sys.exit(0)
+
+def escalate(ctx: StepContext, reason: str, exception: Optional[Exception] = None) -> None:
+    """
+    Same as fail_safe but also prints ESCALATE to stderr, exit 1.
+    """
+    print(f"[ESCALATE] {reason}", file=sys.stderr)
+    if exception:
+        print(f"[ESCALATE] Exception: {exception}", file=sys.stderr)
+        
+    try:
+        step_context_advance(ctx, AgentState.ESCALATE, reason)
+    except IllegalTransitionError:
+        ctx.state = AgentState.ESCALATE
+        
+    checkpoint_file = Path(f"/tmp/heypiggy_run_{ctx.run_id}_checkpoint.json")
+    try:
+        with open(checkpoint_file, "w") as f:
+            json.dump({
+                "state": ctx.state.name,
+                "step_index": ctx.step_index,
+                "run_id": ctx.run_id,
+                "reason": reason,
+                "exception": str(exception) if exception else None
+            }, f, indent=2)
+    except Exception:
+        pass
+        
+    print(f"[ESCALATE] Exiting with error.", file=sys.stderr)
+    sys.exit(1)
+

--- a/heypiggy_vision_worker.py
+++ b/heypiggy_vision_worker.py
@@ -49,6 +49,13 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+# --- State Machine ---
+from agent_state_machine import (
+    AgentState, StepContext, step_context_advance,
+    fail_safe, escalate, IllegalTransitionError
+)
+
+
 # ============================================================================
 # USER PROFIL — Jeremy Schulze
 # WHY: Der Worker muss Profil-Fragen (Region, Wohnort, Geschlecht, Name etc.)
@@ -2084,6 +2091,9 @@ async def run_click_action(
 
 
 async def main():
+    ctx = StepContext(state=AgentState.INIT)
+    step_context_advance(ctx, AgentState.PREFLIGHT, "Initializing worker")
+
     audit(
         "start",
         message="A2A-SIN-Worker-HeyPiggy Vision Gate v2.0",
@@ -2111,6 +2121,7 @@ async def main():
 
     # 3. VISION GATE CONTROLLER INITIALISIEREN
     gate = VisionGateController()
+    step_context_advance(ctx, AgentState.ACQUIRE_SESSION, "Starting acquisition")
 
     # 4. INITIALE NAVIGATION
     action_desc = "Navigiere zu HeyPiggy Dashboard"
@@ -2158,6 +2169,11 @@ async def main():
 
     # 5. VISION GATE LOOP — Das Herzstück
     while gate.should_continue():
+        ctx.no_progress_counter = gate.no_progress_count
+        ctx.step_index = gate.total_steps
+        if not gate.should_continue():
+            fail_safe(ctx, "Gate should not continue (max steps or retries reached)")
+            break
         # ---- Bridge-Health-Check vor JEDER Iteration ----
         if not await check_bridge_alive():
             audit("stop", reason="Bridge nicht erreichbar, Abbruch")
@@ -2177,6 +2193,7 @@ async def main():
         await human_delay(5.0, 10.0)
 
         # ---- VISION CHECK ----
+        step_context_advance(ctx, AgentState.ASSESS_PAGE, "Assessing current page visual state")
         decision = await ask_vision(
             img_path, action_desc, expected, gate.total_steps + 1
         )
@@ -2189,6 +2206,28 @@ async def main():
         progress = decision.get("progress", False)
 
         # Schritt aufzeichnen
+                # Map page_state to actual FSM states where appropriate
+        try:
+            if page_state == "login":
+                step_context_advance(ctx, AgentState.AUTHENTICATE, "Login page detected")
+            elif page_state == "onboarding":
+                step_context_advance(ctx, AgentState.ONBOARD, "Onboarding page detected")
+            elif page_state == "dashboard":
+                step_context_advance(ctx, AgentState.DISCOVER_WORK, "Dashboard detected")
+            elif page_state == "survey":
+                step_context_advance(ctx, AgentState.SELECT_TASK, "Survey selection detected")
+            elif page_state == "survey_active":
+                if ctx.state == AgentState.SELECT_TASK:
+                    step_context_advance(ctx, AgentState.ENTER_TASK, "Entering task")
+                step_context_advance(ctx, AgentState.EXECUTE_TASK_LOOP, "Executing task loop")
+            elif page_state == "survey_done":
+                step_context_advance(ctx, AgentState.VALIDATE_OUTCOME, "Survey completed")
+                step_context_advance(ctx, AgentState.RECORD_RESULT, "Recording result")
+            elif verdict == "STOP":
+                pass # handled below
+        except IllegalTransitionError as e:
+            audit("warning", message=f"State transition ignored: {e}")
+            
         gate.record_step(verdict, img_hash, page_state)
 
         print(f"\n{'=' * 60}")
@@ -2226,6 +2265,10 @@ async def main():
                 total_steps=gate.total_steps,
             )
             await save_session("completed")
+            try:
+                step_context_advance(ctx, AgentState.COMPLETE, "Task marked completed by vision")
+            except IllegalTransitionError:
+                pass
             break
 
         # ---- SURVEY DONE — Bestätigungsseite erkannt ----

--- a/heypiggy_vision_worker.py
+++ b/heypiggy_vision_worker.py
@@ -2091,7 +2091,15 @@ async def run_click_action(
 
 
 async def main():
-    ctx = StepContext(state=AgentState.INIT)
+    # WHY: The FSM context is created before any real work begins so the worker
+    # can track phase, loop progress, page fingerprints, and recovery metadata
+    # from the very first step onward.
+    ctx = StepContext(
+        state=AgentState.INIT,
+        step_index=0,
+        max_steps=MAX_STEPS,
+        task_url="https://www.heypiggy.com/login",
+    )
     step_context_advance(ctx, AgentState.PREFLIGHT, "Initializing worker")
 
     audit(
@@ -2169,11 +2177,15 @@ async def main():
 
     # 5. VISION GATE LOOP — Das Herzstück
     while gate.should_continue():
+        # WHY: The gate owns the raw loop counters, but the FSM context must mirror
+        # them so fail-safe checkpoints and structured state logs contain the latest
+        # safety-relevant execution metadata.
         ctx.no_progress_counter = gate.no_progress_count
         ctx.step_index = gate.total_steps
+        if ctx.no_progress_counter >= MAX_NO_PROGRESS:
+            fail_safe(ctx, "Gate detected no progress threshold exhaustion")
         if not gate.should_continue():
             fail_safe(ctx, "Gate should not continue (max steps or retries reached)")
-            break
         # ---- Bridge-Health-Check vor JEDER Iteration ----
         if not await check_bridge_alive():
             audit("stop", reason="Bridge nicht erreichbar, Abbruch")
@@ -2183,6 +2195,9 @@ async def main():
         img_path, img_hash = await take_screenshot(
             gate.total_steps + 1, label=action_desc[:20]
         )
+        # WHY: The latest screenshot hash is the canonical page fingerprint the FSM
+        # can persist into checkpoints for progress and recovery analysis.
+        ctx.last_page_fingerprint = img_hash or ""
         if not img_path:
             gate.record_step("RETRY", None)
             await human_delay(2.0, 4.0)
@@ -2346,6 +2361,9 @@ async def main():
             # Navigation — IMMER mit exaktem tabId, KEIN Fallback ohne tabId
             elif next_action == "navigate":
                 url = next_params.get("url", "")
+                # WHY: The FSM context should remember the latest task/dashboard URL so
+                # checkpoint files can explain exactly where the worker was headed.
+                ctx.task_url = url or ctx.task_url
                 await execute_bridge("navigate", {"url": url, **_tab_params()})
                 await save_session(f"nav_{gate.total_steps}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest bootstrap helpers for local repository imports.
+
+This file exists so the exact command requested by the issue,
+`pytest tests/test_state_machine.py -v`, works without relying on an
+external `PYTHONPATH=.` shell prefix.
+
+WHY:
+- Pytest may start with the tests directory as the first import root in this
+  repository layout.
+- `agent_state_machine.py` lives at the repository root, not inside an
+  installed package.
+- Without a small import bootstrap, `from agent_state_machine import ...`
+  can fail during collection depending on how pytest is invoked.
+
+CONSEQUENCES:
+- We insert the repository root into `sys.path` once at collection time.
+- The production worker code remains unchanged.
+- The acceptance command becomes reproducible in a plain shell.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Resolve the repository root relative to this file instead of relying on the
+# current working directory. This keeps imports stable even if pytest is started
+# from a parent directory or a tool wrapper changes cwd behavior.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# Insert the repository root at the front of `sys.path` only when it is not
+# already present. This preserves deterministic imports while avoiding duplicate
+# path entries.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,71 +1,150 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for the typed OpenSIN worker state machine.
+
+WHY THESE TESTS EXIST:
+- The FSM is a safety primitive, so the legal paths must be executable and the
+  illegal paths must fail loudly.
+- Terminal helpers must checkpoint and exit deterministically because the worker
+  depends on them for safe shutdown behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
 import pytest
-import sys
+
 from agent_state_machine import (
-    AgentState, StepContext, step_context_advance,
-    fail_safe, escalate, IllegalTransitionError
+    AgentState,
+    IllegalTransitionError,
+    StepContext,
+    escalate,
+    fail_safe,
+    step_context_advance,
 )
 
-def test_init_to_acquire_session():
-    ctx = StepContext(state=AgentState.INIT)
-    step_context_advance(ctx, AgentState.PREFLIGHT, "preflight ok")
-    assert ctx.state == AgentState.PREFLIGHT
-    step_context_advance(ctx, AgentState.ACQUIRE_SESSION, "acquire session ok")
+
+# WHY: The production dataclass requires explicit `state` and `step_index`, so
+# this helper keeps the tests concise while still creating realistic contexts.
+def make_context(state: AgentState) -> StepContext:
+    """Create a minimal but realistic FSM context for tests."""
+
+    return StepContext(state=state, step_index=0)
+
+
+# WHY: Terminal helpers always write `checkpoint.json` into the current working
+# directory. Running the tests inside a temp directory keeps the repository clean.
+@pytest.fixture
+def isolated_checkpoint_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run checkpoint-producing tests inside an isolated temporary directory."""
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# WHY: Repeated assertions against the checkpoint format should stay centralized
+# so every terminal-path test validates the same artifact structure consistently.
+def read_checkpoint(tmp_dir: Path) -> dict[str, object]:
+    """Load the checkpoint written by fail-safe or escalation helpers."""
+
+    checkpoint_path = tmp_dir / "checkpoint.json"
+    assert checkpoint_path.exists(), "checkpoint.json was not written"
+    return json.loads(checkpoint_path.read_text(encoding="utf-8"))
+
+
+# WHY: This verifies the worker can move through the earliest bootstrap stages
+# without being blocked by the transition table.
+def test_init_prefight_acquire_session_happy_path() -> None:
+    """INIT -> PREFLIGHT -> ACQUIRE_SESSION should be legal."""
+
+    ctx = make_context(AgentState.INIT)
+    step_context_advance(ctx, AgentState.PREFLIGHT, "preflight start")
+    step_context_advance(ctx, AgentState.ACQUIRE_SESSION, "session acquisition start")
+
     assert ctx.state == AgentState.ACQUIRE_SESSION
+    assert ctx.step_index == 2
 
-def test_authenticate_to_select_task():
-    ctx = StepContext(state=AgentState.AUTHENTICATE)
-    step_context_advance(ctx, AgentState.ONBOARD, "auth ok")
-    assert ctx.state == AgentState.ONBOARD
-    step_context_advance(ctx, AgentState.DISCOVER_WORK, "onboard ok")
-    assert ctx.state == AgentState.DISCOVER_WORK
-    step_context_advance(ctx, AgentState.SELECT_TASK, "work discovered")
+
+# WHY: This covers the middle-of-flow account and task discovery progression the
+# worker needs before it can actually enter a survey.
+def test_authenticate_onboard_discover_select_happy_path() -> None:
+    """AUTHENTICATE -> ONBOARD -> DISCOVER_WORK -> SELECT_TASK should be legal."""
+
+    ctx = make_context(AgentState.AUTHENTICATE)
+    step_context_advance(ctx, AgentState.ONBOARD, "credentials accepted")
+    step_context_advance(ctx, AgentState.DISCOVER_WORK, "onboarding complete")
+    step_context_advance(ctx, AgentState.SELECT_TASK, "tasks visible")
+
     assert ctx.state == AgentState.SELECT_TASK
+    assert ctx.step_index == 3
 
-def test_execute_to_complete():
-    ctx = StepContext(state=AgentState.EXECUTE_TASK_LOOP)
-    step_context_advance(ctx, AgentState.VALIDATE_OUTCOME, "executed")
-    assert ctx.state == AgentState.VALIDATE_OUTCOME
-    step_context_advance(ctx, AgentState.RECORD_RESULT, "validated")
-    assert ctx.state == AgentState.RECORD_RESULT
-    step_context_advance(ctx, AgentState.COMPLETE, "recorded")
+
+# WHY: This confirms the worker can progress from active execution to final
+# completion through the required validation and recording phases.
+def test_execute_validate_record_complete_happy_path() -> None:
+    """EXECUTE_TASK_LOOP -> VALIDATE_OUTCOME -> RECORD_RESULT -> COMPLETE should be legal."""
+
+    ctx = make_context(AgentState.EXECUTE_TASK_LOOP)
+    step_context_advance(ctx, AgentState.VALIDATE_OUTCOME, "task loop finished")
+    step_context_advance(ctx, AgentState.RECORD_RESULT, "outcome validated")
+    step_context_advance(ctx, AgentState.COMPLETE, "result persisted")
+
     assert ctx.state == AgentState.COMPLETE
+    assert ctx.step_index == 3
 
-def test_no_progress_fail_safe(monkeypatch):
-    ctx = StepContext(state=AgentState.EXECUTE_TASK_LOOP)
+
+# WHY: The no-progress threshold is a hard safety stop. This test proves that a
+# stuck worker can always transition into FAIL_SAFE and emit a checkpoint.
+def test_any_state_to_fail_safe_when_no_progress_threshold_reached(
+    isolated_checkpoint_dir: Path,
+) -> None:
+    """Any state should be able to fail-safe once no-progress reaches the limit."""
+
+    ctx = make_context(AgentState.EXECUTE_TASK_LOOP)
     ctx.no_progress_counter = 15
-    
-    exited = False
-    def mock_exit(code):
-        nonlocal exited
-        exited = True
-        assert code == 0
-        
-    monkeypatch.setattr(sys, 'exit', mock_exit)
-    
-    if ctx.no_progress_counter >= 15:
-        fail_safe(ctx, "no progress limit reached")
-        
-    assert exited
+
+    with pytest.raises(SystemExit) as exit_info:
+        if ctx.no_progress_counter >= 15:
+            fail_safe(ctx, "no progress threshold reached")
+
+    assert exit_info.value.code == 0
     assert ctx.state == AgentState.FAIL_SAFE
 
-def test_escalate(monkeypatch):
-    ctx = StepContext(state=AgentState.ASSESS_PAGE)
-    
-    exited = False
-    def mock_exit(code):
-        nonlocal exited
-        exited = True
-        assert code == 1
-        
-    monkeypatch.setattr(sys, 'exit', mock_exit)
-    
-    escalate(ctx, "retry exhausted", Exception("timeout"))
-        
-    assert exited
+    checkpoint = read_checkpoint(isolated_checkpoint_dir)
+    assert checkpoint["state"] == "FAIL_SAFE"
+    assert checkpoint["reason"] == "no progress threshold reached"
+
+
+# WHY: Retry exhaustion is the canonical escalation case. The test proves that
+# escalation is callable, writes a checkpoint, and exits with a failure code.
+def test_any_state_to_escalate_when_retry_exhaustion_is_detected(
+    isolated_checkpoint_dir: Path,
+) -> None:
+    """Any state should be able to escalate after retry exhaustion."""
+
+    ctx = make_context(AgentState.ASSESS_PAGE)
+
+    with pytest.raises(SystemExit) as exit_info:
+        escalate(ctx, "retry exhaustion simulated", exception=RuntimeError("timeout"))
+
+    assert exit_info.value.code == 1
     assert ctx.state == AgentState.ESCALATE
 
-def test_illegal_transition():
-    ctx = StepContext(state=AgentState.INIT)
-    with pytest.raises(IllegalTransitionError):
-        step_context_advance(ctx, AgentState.COMPLETE, "invalid jump")
+    checkpoint = read_checkpoint(isolated_checkpoint_dir)
+    assert checkpoint["state"] == "ESCALATE"
+    assert checkpoint["reason"] == "retry exhaustion simulated"
+    assert "RuntimeError('timeout')" in str(checkpoint["exception"])
 
+
+# WHY: The entire point of the FSM is to reject impossible jumps. This test
+# protects against accidental loosening of the transition table.
+def test_invalid_transition_raises_illegal_transition_error() -> None:
+    """A disallowed state jump should raise IllegalTransitionError."""
+
+    ctx = make_context(AgentState.INIT)
+
+    with pytest.raises(IllegalTransitionError):
+        step_context_advance(ctx, AgentState.COMPLETE, "illegal shortcut")

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,0 +1,71 @@
+import pytest
+import sys
+from agent_state_machine import (
+    AgentState, StepContext, step_context_advance,
+    fail_safe, escalate, IllegalTransitionError
+)
+
+def test_init_to_acquire_session():
+    ctx = StepContext(state=AgentState.INIT)
+    step_context_advance(ctx, AgentState.PREFLIGHT, "preflight ok")
+    assert ctx.state == AgentState.PREFLIGHT
+    step_context_advance(ctx, AgentState.ACQUIRE_SESSION, "acquire session ok")
+    assert ctx.state == AgentState.ACQUIRE_SESSION
+
+def test_authenticate_to_select_task():
+    ctx = StepContext(state=AgentState.AUTHENTICATE)
+    step_context_advance(ctx, AgentState.ONBOARD, "auth ok")
+    assert ctx.state == AgentState.ONBOARD
+    step_context_advance(ctx, AgentState.DISCOVER_WORK, "onboard ok")
+    assert ctx.state == AgentState.DISCOVER_WORK
+    step_context_advance(ctx, AgentState.SELECT_TASK, "work discovered")
+    assert ctx.state == AgentState.SELECT_TASK
+
+def test_execute_to_complete():
+    ctx = StepContext(state=AgentState.EXECUTE_TASK_LOOP)
+    step_context_advance(ctx, AgentState.VALIDATE_OUTCOME, "executed")
+    assert ctx.state == AgentState.VALIDATE_OUTCOME
+    step_context_advance(ctx, AgentState.RECORD_RESULT, "validated")
+    assert ctx.state == AgentState.RECORD_RESULT
+    step_context_advance(ctx, AgentState.COMPLETE, "recorded")
+    assert ctx.state == AgentState.COMPLETE
+
+def test_no_progress_fail_safe(monkeypatch):
+    ctx = StepContext(state=AgentState.EXECUTE_TASK_LOOP)
+    ctx.no_progress_counter = 15
+    
+    exited = False
+    def mock_exit(code):
+        nonlocal exited
+        exited = True
+        assert code == 0
+        
+    monkeypatch.setattr(sys, 'exit', mock_exit)
+    
+    if ctx.no_progress_counter >= 15:
+        fail_safe(ctx, "no progress limit reached")
+        
+    assert exited
+    assert ctx.state == AgentState.FAIL_SAFE
+
+def test_escalate(monkeypatch):
+    ctx = StepContext(state=AgentState.ASSESS_PAGE)
+    
+    exited = False
+    def mock_exit(code):
+        nonlocal exited
+        exited = True
+        assert code == 1
+        
+    monkeypatch.setattr(sys, 'exit', mock_exit)
+    
+    escalate(ctx, "retry exhausted", Exception("timeout"))
+        
+    assert exited
+    assert ctx.state == AgentState.ESCALATE
+
+def test_illegal_transition():
+    ctx = StepContext(state=AgentState.INIT)
+    with pytest.raises(IllegalTransitionError):
+        step_context_advance(ctx, AgentState.COMPLETE, "invalid jump")
+


### PR DESCRIPTION
## Summary
- add a typed `AgentState` finite state machine with guarded transitions, structured step context, and terminal fail-safe/escalation helpers
- wire the HeyPiggy worker into the new state tracking flow so core page phases map onto explicit FSM states
- add focused pytest coverage plus a bootstrap `conftest.py` so `pytest tests/test_state_machine.py -v` passes as requested

## Testing
- pytest tests/test_state_machine.py -v

## Issues
- refs #5
- refs #6
- refs #7
- refs #8