### PR TITLE
[E2] Vision Gate V2 — Schema-Validated Perception

### DIFF
--- a/heypiggy_vision_worker.py
+++ b/heypiggy_vision_worker.py
@@ -49,6 +49,10 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+from predicate_checks import predicate_post_check, predicate_pre_check
+from vision_contract import NextAction, VisionResponse, VisionVerdict, parse_vision_response
+from vision_prompt import build_vision_prompt
+
 # ============================================================================
 # USER PROFIL — Jeremy Schulze
 # WHY: Der Worker muss Profil-Fragen (Region, Wohnort, Geschlecht, Name etc.)
@@ -1158,6 +1162,143 @@ async def dom_prescan():
     return "\n\n".join(filter(None, [page_context, snapshot_info, clickable_info]))
 
 
+def _page_type_to_page_state(page_type: str) -> str:
+    """
+    Übersetzt den neuen Vision-V2 `page_type` in die vorhandenen Worker-Zustände.
+    WHY: Der Rest des Workers arbeitet weiterhin mit den etablierten Zustandsnamen
+         (`page_state`), während der neue Vision-Vertrag bewusst kompakter ist.
+    CONSEQUENCES: Die Integration bleibt klein und rückwärtskompatibel.
+    """
+    mapping = {
+        "login": "login",
+        "survey_list": "dashboard",
+        "survey_question": "survey_active",
+        "survey_complete": "survey_done",
+        "captcha": "captcha",
+        "unknown": "unknown",
+    }
+    return mapping.get((page_type or "unknown").strip().lower(), "unknown")
+
+
+
+def _next_action_to_worker_command(next_action: NextAction) -> tuple[str, dict]:
+    """
+    Übersetzt die generische Vision-V2 Aktion in konkrete Worker-/Bridge-Befehle.
+    WHY: Der JSON-Vertrag soll modellseitig generisch bleiben, während der Worker
+         weiterhin seine bestehenden spezialisierten Klick- und Scrollpfade nutzt.
+    CONSEQUENCES: Alte Bridge-Methoden können weiterverwendet werden, ohne dass das
+                  Modell deren gesamte interne Namenswelt kennen muss.
+    """
+    action_type = (next_action.type or "none").strip().lower()
+    target = (next_action.target or "").strip()
+    value = (next_action.value or "").strip()
+
+    if action_type == "click":
+        if target.startswith("selector:"):
+            return "click_element", {"selector": target.split(":", 1)[1].strip()}
+        if target.startswith("ref:"):
+            return "click_ref", {"ref": target.split(":", 1)[1].strip()}
+        if target.startswith("text:"):
+            return "vision_click", {"description": target.split(":", 1)[1].strip()}
+        if target.startswith("coords:"):
+            coords = target.split(":", 1)[1].split(",", 1)
+            if len(coords) == 2:
+                try:
+                    return "click_coordinates", {
+                        "x": int(coords[0].strip()),
+                        "y": int(coords[1].strip()),
+                    }
+                except ValueError:
+                    pass
+        if target:
+            return "vision_click", {"description": target}
+        return "none", {}
+
+    if action_type == "type":
+        selector = target.split(":", 1)[1].strip() if target.startswith("selector:") else target
+        return "type_text", {"selector": selector, "text": value}
+
+    if action_type == "scroll":
+        direction = value.lower() if value else "down"
+        if direction in {"up", "scroll_up"}:
+            return "scroll_up", {}
+        return "scroll_down", {}
+
+    if action_type == "wait":
+        return "wait", {"reason": value or target or "vision_requested_wait"}
+
+    return "none", {}
+
+
+
+def _copy_vision_response(response: VisionResponse, update: dict) -> VisionResponse:
+    """
+    Erstellt ein aktualisiertes VisionResponse-Objekt kompatibel mit Pydantic v1/v2.
+    WHY: HF-VMs können je nach Image unterschiedliche Pydantic-Versionen haben.
+    CONSEQUENCES: Die Policy-Logik bleibt versionsstabil und testbar.
+    """
+    if hasattr(response, "model_copy"):
+        return response.model_copy(update=update)
+    return response.copy(update=update)
+
+
+
+def _apply_vision_response_policy(response: VisionResponse) -> VisionResponse:
+    """
+    Erzwingt fail-closed Worker-Regeln auf dem bereits geparsten Vision-Objekt.
+    WHY: Auch formal gültiges JSON darf die Schleife nicht blind fortsetzen, wenn
+         die Konfidenz zu niedrig ist oder ein nicht lösbarer Blocker vorliegt.
+    CONSEQUENCES: Niedrige Sicherheit wird deterministisch zu RETRY oder ESCALATE.
+    """
+    if response.confidence < 0.6:
+        return _copy_vision_response(
+            response,
+            {
+                "verdict": VisionVerdict.RETRY,
+                "reasoning": (
+                    f"Low-confidence vision response ({response.confidence:.2f}); retry required."
+                ),
+                "next_action": NextAction(type="none", target="", value=""),
+            },
+        )
+
+    if response.blocker and not response.blocker.auto_resolvable:
+        return _copy_vision_response(response, {"verdict": VisionVerdict.ESCALATE})
+
+    return response
+
+
+
+def _vision_response_to_decision(response: VisionResponse) -> dict:
+    """
+    Wandelt das strikte Vision-V2 Modell in das bestehende Worker-Decision-Dict um.
+    WHY: So kann der Hauptloop minimal angepasst werden, während Tests und Prompt
+         bereits vollständig auf dem neuen Vertrag laufen.
+    CONSEQUENCES: Alte Konsumenten lesen weiterhin `page_state`, `next_action` und
+                  `next_params`, bekommen diese Felder jetzt aber aus validiertem JSON.
+    """
+    next_action_name, next_params = _next_action_to_worker_command(response.next_action)
+    blocker = response.blocker
+    return {
+        "verdict": response.verdict.value,
+        "confidence": response.confidence,
+        "page_type": response.page_type,
+        "page_state": _page_type_to_page_state(response.page_type),
+        "reason": response.reasoning,
+        "progress": bool(response.dom_hash),
+        "next_action": next_action_name,
+        "next_params": next_params,
+        "dom_hash": response.dom_hash,
+        "blocker": {
+            "type": blocker.type,
+            "detail": blocker.detail,
+            "auto_resolvable": blocker.auto_resolvable,
+        }
+        if blocker
+        else None,
+    }
+
+
 # ============================================================================
 # VISION GATE — Gemini 3 Flash Analyse mit gehärtetem Prompt + DOM-Kontext
 # ============================================================================
@@ -1167,117 +1308,23 @@ async def ask_vision(
     screenshot_path: str, action_desc: str, expected: str, step_num: int
 ):
     """
-    Sendet einen Screenshot + DOM-Kontext an Gemini 3 Flash.
-    WHY: KEIN EINZIGER KLICK ohne dass das Vision-Modell den Bildschirm gesehen hat.
-    CONSEQUENCES: Bei Parse-Fehler wird RETRY zurückgegeben (nie ein Crash).
+    Sendet einen Screenshot + DOM-Kontext an das Vision-Modell und erzwingt den
+    Vision-Gate-V2 JSON-Vertrag.
+    WHY: Das Modell darf keine freien Texte mehr liefern, weil die Worker-Logik
+         auf einem strikt validierten Antwortschema aufbauen muss.
+    CONSEQUENCES: Jede Antwort wird über `parse_vision_response()` normalisiert;
+                  bei Parse- oder Policy-Fehlern fällt der Worker fail-closed auf
+                  RETRY oder STOP zurück.
     """
-    # DOM Pre-Scan: Echte Selektoren VOR dem Vision-Call holen!
+    # DOM-Kontext bleibt Pflicht, damit das Modell echte Selektoren und Ref-Hinweise
+    # sieht statt sich Klick-Ziele auszudenken.
     dom_context = await dom_prescan()
 
-    # Profil-Kontext aus gespeichertem User-Profil laden
-    # WHY: Gemini muss wissen wer der User ist um Profil-Fragen korrekt zu beantworten.
-    #      Ohne Profil würde Gemini zufällig wählen → falsche Region, falscher Name etc.
+    # Profil-Kontext bleibt zusätzlich erhalten, damit Profil- und Login-Fragen auf
+    # echten Nutzerdaten basieren statt auf Fantasie-Antworten.
     profile_context = _build_profile_context()
-
-    prompt = f"""Du bist der Vision Gate Controller der OpenSIN-Bridge.
-
-KONTEXT:
-- Letzte Aktion: '{action_desc}'
-- Erwartetes Ergebnis: '{expected}'
-- Schritt Nummer: {step_num} von maximal {MAX_STEPS}
-
-{profile_context}
-
-{dom_context}
-
-AUFGABE — Analysiere den Screenshot UND die DOM-Daten oben PRÄZISE:
-
-1. BLOCKIERUNGEN: Sind Captchas, Cookie-Banner, Consent-Modals, Login-Dialoge, Popups, Overlays oder Error-Messages sichtbar?
-   → Wenn ja: Diese ZUERST schliessen/akzeptieren!
-
-2. AKTUELLER STATUS: Was zeigt die Seite GENAU an?
-
-3. FORTSCHRITT: Hat sich gegenüber der letzten Aktion etwas verändert?
-
-4. NÄCHSTE AKTION: Was muss als nächstes passieren?
-
-VERFÜGBARE AKTIONEN (wähle GENAU EINE):
-- "click_element" — Standard CSS-Selektor Klick. Params: {{"selector": "#id-oder-.klasse"}}
-- "click_ref" — Klick per Accessibility-Tree-Ref (z.B. @e9). BEVORZUGT für Radio-Buttons, Checkboxen, Links ohne ID! Params: {{"ref": "@e9"}}
-- "ghost_click" — Voller Pointer+Mouse Event-Stack für SPA/React-Elemente. Params: {{"selector": "#echte-id"}}
-- "vision_click" — Beschreibungsbasierter Klick. Params: {{"description": "Text des Elements"}}
-- "click_coordinates" — Absoluter Pixel-Klick. Params: {{"x": 100, "y": 200}}
-- "keyboard" — Tastatur verwenden (z.B. Tab, Enter). Params: {{"keys": ["Enter"], "selector": "#optional-id"}}
-- "type_text" — Text eingeben. Params: {{"selector": "css", "text": "wert"}}
-- "navigate" — URL aufrufen. Params: {{"url": "https://..."}}
-- "scroll_down" — Seite nach unten scrollen
-- "scroll_up" — Seite nach oben scrollen
-- "none" — Aufgabe erledigt, nichts mehr zu tun
-
-ABSOLUTE PFLICHT-REGELN FÜR SELEKTOREN:
-- NUTZE NUR Selektoren aus der DOM-Analyse oben! NIEMALS raten!
-- Pseudo-Selektoren wie :has-text(), :contains(), :has() sind VERBOTEN (existieren nicht in CSS)!
-- Bevorzuge #id Selektoren (z.B. #survey-65076903) — die sind IMMER eindeutig!
-- WICHTIG: input[type='radio'][value='X'] NIEMALS nutzen — HeyPiggy Radio-Buttons haben KEINE value= Attribute!
-- Für Radio-Buttons → IMMER click_ref mit dem @eX Ref aus dem ACCESSIBILITY-TREE oben nutzen!
-- Für Survey-Karten auf HeyPiggy: Die Klasse ist .survey-item (NICHT .survey-card!), jede Karte hat eine eindeutige ID wie #survey-XXXXXXXX
-- Nutze ghost_click für alle div-basierten Karten (cursor: pointer)
-- Playwright-only Texte-Selektoren wie :contains(), :has-text() oder :text() sind VERBOTEN.
-- Wenn du Textreferenz brauchst, nenne den echten CSS-Selektor aus dem DOM-Pre-Scan oder eine eindeutige #id.
-- CONSENT-MODAL "Nächste" Button: IMMER #submit-button-cpx nutzen! NIEMALS button.modal-button-positive — das trifft dutzende versteckte Buttons im DOM und funktioniert nicht!
-
-KLICK-STRATEGIE:
-- Für Radio-Buttons ([radio @eX] im Accessibility-Tree) → click_ref mit {{"ref": "@eX"}} — das ist PFLICHT!
-- Für <button>, <a>, <input> → click_element
-- Für div.survey-item / div[cursor=pointer] → ghost_click mit #id-Selektor
-- Für Elemente ohne CSS-Selektor → vision_click mit Beschreibung
-- Letzter Ausweg → click_coordinates mit x,y aus der DOM-Analyse
-
-PAGE STATE REGELN — KRITISCH:
-- "dashboard" → HeyPiggy Startseite mit Survey-Liste, noch keine Umfrage gestartet
-- "login" → Login-Formular sichtbar
-- "onboarding" → Profil-Modal/Onboarding-Fragen (Region, Name, etc.) — VOR dem eigentlichen Dashboard!
-- "survey_active" → UMFRAGE LÄUFT GERADE! Fragen werden angezeigt (Radio-Buttons, Dropdowns, Textfelder, Skalen). NIEMALS "none" zurückgeben solange Fragen sichtbar sind!
-- "survey" → Survey-Auswahl / Übergangsseite (zwischen Dashboard und aktiver Umfrage)
-- "survey_done" → Umfrage erfolgreich abgeschlossen, Bestätigungsseite
-- "error" → Fehlermeldung, Timeout oder unbekannter Zustand
-- "unknown" → Seite nicht klar erkennbar
-
-PROFIL-FRAGEN REGELN — KRITISCH:
-- Wenn ein Modal mit Profil-Fragen sichtbar ist (Region, Wohnort, Geschlecht, Name, Alter etc.):
-  page_state="onboarding" setzen!
-- Nutze IMMER das BENUTZERPROFIL oben um die korrekte Antwort zu wählen!
-- Region-Frage ("In welcher Region wohnst du?"): IMMER "Norden" wählen (Jeremy wohnt in Berlin, wählt Norden)
-- Nach Auswahl der Antwort → "Nächste"/"Weiter" Button klicken!
-- Profil-Modals MÜSSEN vollständig ausgefüllt werden bevor Umfragen gestartet werden!
-
-UMFRAGE-REGELN — ÄUSSERST WICHTIG:
-- Wenn page_state="survey_active": BEENDE DIE UMFRAGE VOLLSTÄNDIG! Klicke ALLE Fragen durch bis zur Bestätigungsseite!
-- Wenn eine Frage sichtbar ist → IMMER beantworten und "Weiter"/"Next"/"Submit" klicken!
-- NIEMALS next_action="none" wenn noch Fragen offen sind!
-- Radio-Button Fragen → click_ref mit dem @eX Ref aus dem Accessibility-Tree (NICHT click_element mit value=!)
-- Dropdown-Fragen → click_element auf die gewünschte Option
-- Freitext-Fragen → type_text mit einer sinnvollen Antwort
-- Skalen-Fragen (1-5, 1-7, etc.) → click_element auf mittlere oder positive Option
-- "Weiter"/"Next"/"Fortfahren"/"Continue"/"Submit" Buttons → IMMER klicken nach einer Antwort!
-- Fortschrittsbalken sichtbar? → Umfrage läuft noch, page_state="survey_active"!
-
-REGELN:
-- Antworte AUSSCHLIESSLICH mit gültigem JSON! Kein Markdown, kein Text!
-- Bei Captchas oder unlösbaren Blockierungen: verdict="STOP"
-- Bei unveränderter Seite: verdict="RETRY" und schlage eine ANDERE Methode vor!
-- Credentials NIEMALS ausgeben! Nutze "<EMAIL>" und "<PASSWORD>" als Platzhalter.
-- Wähle IMMER die lukrativste verfügbare Umfrage (höchster €-Betrag)!
-
-ANTWORT-FORMAT (NUR dieses JSON, NICHTS anderes):
-{{
-  "verdict": "PROCEED",
-  "page_state": "dashboard|login|onboarding|survey|survey_active|survey_done|error|unknown",
-  "reason": "Kurze Analyse...",
-  "progress": true,
-  "next_action": "click_ref",
-  "next_params": {{"ref": "@e9"}}
-}}"""
+    prompt_dom_snapshot = "\n\n".join(filter(None, [profile_context, dom_context]))
+    prompt = build_vision_prompt(action_desc, expected, prompt_dom_snapshot)
 
     run_result = await run_vision_model(
         prompt,
@@ -1290,68 +1337,69 @@ ANTWORT-FORMAT (NUR dieses JSON, NICHTS anderes):
         error_reason = run_result.get("error", "Vision call failed")
         if run_result.get("auth_failure"):
             return {
-                "verdict": "STOP",
+                "verdict": VisionVerdict.STOP.value,
+                "confidence": 0.0,
                 "reason": f"Vision auth failed: {error_reason}",
                 "next_action": "none",
+                "next_params": {},
                 "page_state": "error",
+                "page_type": "unknown",
                 "progress": False,
+                "dom_hash": "",
+                "blocker": {
+                    "type": "auth",
+                    "detail": error_reason,
+                    "auto_resolvable": False,
+                },
             }
         return {
-            "verdict": "RETRY",
+            "verdict": VisionVerdict.RETRY.value,
+            "confidence": 0.0,
             "reason": error_reason,
             "next_action": "none",
+            "next_params": {},
             "page_state": "unknown",
+            "page_type": "unknown",
             "progress": False,
+            "dom_hash": "",
+            "blocker": None,
         }
 
     full_text = run_result.get("text", "")
 
     try:
-        # Markdown-Block entfernen falls vorhanden
-        if "```json" in full_text:
-            full_text = full_text.split("```json")[1].split("```")[0].strip()
-        elif "```" in full_text:
-            parts = full_text.split("```")
-            if len(parts) >= 3:
-                full_text = parts[1].strip()
-                # Falls der erste Teil nach ``` mit "json" beginnt, entfernen
-                if full_text.startswith("json"):
-                    full_text = full_text[4:].strip()
-
-        result = json.loads(full_text)
+        response = parse_vision_response(full_text)
+        response = _apply_vision_response_policy(response)
+        decision = _vision_response_to_decision(response)
         audit(
             "vision_check",
             step=step_num,
-            verdict=result.get("verdict"),
-            page_state=result.get("page_state"),
-            reason=result.get("reason", "")[:150],
-            next_action=result.get("next_action"),
+            verdict=decision.get("verdict"),
+            confidence=decision.get("confidence"),
+            page_state=decision.get("page_state"),
+            reason=decision.get("reason", "")[:150],
+            next_action=decision.get("next_action"),
         )
-        return result
+        return decision
 
-    except json.JSONDecodeError as e:
+    except Exception as e:
         audit(
             "error",
-            message=f"Vision JSON Parse Error: {e}",
+            message=f"Vision contract parse error: {e}",
             step=step_num,
             raw_output=full_text[:500],
         )
         return {
-            "verdict": "RETRY",
-            "reason": f"JSON Parse Error: {e}",
+            "verdict": VisionVerdict.RETRY.value,
+            "confidence": 0.0,
+            "reason": f"Vision contract parse error: {e}",
             "next_action": "none",
+            "next_params": {},
             "page_state": "unknown",
+            "page_type": "unknown",
             "progress": False,
-        }
-
-    except Exception as e:
-        audit("error", message=f"Vision Exception: {e}", step=step_num)
-        return {
-            "verdict": "RETRY",
-            "reason": str(e),
-            "next_action": "none",
-            "page_state": "unknown",
-            "progress": False,
+            "dom_hash": "",
+            "blocker": None,
         }
 
 
@@ -2020,6 +2068,61 @@ def inject_credentials(params: dict, email: str, pwd: str) -> dict:
     return params
 
 
+async def auto_resolve_blocker(
+    blocker: dict | None, next_action: str, next_params: dict, step_num: int
+) -> bool:
+    """
+    Versucht bekannte, explizit als automatisch lösbar markierte Blocker aufzulösen.
+    WHY: Vision Gate V2 liefert jetzt strukturierte Blocker-Daten statt nur Text.
+         Dadurch kann der Worker bei Modals oder Rate-Limits gezielt reagieren.
+    CONSEQUENCES: Gibt nur dann `True` zurück, wenn wirklich eine Auto-Resolution
+                  ausgeführt wurde; nicht lösbare Fälle eskalieren später hart.
+    """
+    if not blocker or not blocker.get("auto_resolvable"):
+        return False
+
+    blocker_type = (blocker.get("type") or "").strip().lower()
+    blocker_detail = blocker.get("detail", "")
+    audit(
+        "state_change",
+        message=f"Auto-resolvable blocker erkannt: {blocker_type} — {blocker_detail[:120]}",
+        step=step_num,
+    )
+
+    # Wenn das Vision-Modell bereits eine konkrete Folgeaktion vorgeschlagen hat,
+    # übernimmt der Hauptloop die tatsächliche Ausführung. Hier melden wir nur,
+    # dass dieser Blocker prinzipiell automatisch behandelbar ist.
+    if next_action != "none":
+        return False
+
+    if blocker_type == "modal":
+        await keyboard_action(["Escape"])
+        return True
+
+    if blocker_type == "rate_limit":
+        await human_delay(4.0, 7.0)
+        return True
+
+    return False
+
+
+
+def _selector_for_predicate(next_action: str, next_params: dict) -> str:
+    """
+    Extrahiert den CSS-Selektor für die DOM-Predicate-Prüfungen.
+    WHY: Nur CSS-Selektoren können zuverlässig auf Sichtbarkeit/Klickbarkeit und
+         Okklusion geprüft werden; Ref- oder Koordinaten-Klicks haben keinen DOM-
+         Selektor, werden aber trotzdem mit einem DOM-Hash-Snapshot versehen.
+    CONSEQUENCES: Selektorlose Aktionen liefern einen leeren String und werden von
+                  den Predicate-Checks als `skipped` behandelt.
+    """
+    if next_action == "type_text":
+        return normalize_selector(next_params.get("selector", ""))
+    if next_action == "click_element":
+        return normalize_selector(next_params.get("selector", ""))
+    return ""
+
+
 # ============================================================================
 # SCROLL-HANDLER
 # ============================================================================
@@ -2181,14 +2284,23 @@ async def main():
             img_path, action_desc, expected, gate.total_steps + 1
         )
 
-        verdict = decision.get("verdict", "RETRY")
+        verdict = decision.get("verdict", VisionVerdict.RETRY.value)
         reason = decision.get("reason", "Kein Grund")
         page_state = decision.get("page_state", "unknown")
+        page_type = decision.get("page_type", "unknown")
         next_action = decision.get("next_action", "none")
         next_params = decision.get("next_params", {})
         progress = decision.get("progress", False)
+        blocker = decision.get("blocker")
+        confidence = float(decision.get("confidence", 0.0) or 0.0)
 
         # Schritt aufzeichnen
+        # WHY: Blocker-Eskalationen müssen VOR dem Gate-Tracking angewendet werden,
+        # damit der Retry-/Stop-Zähler den finalen, nicht den vorläufigen Zustand sieht.
+        if blocker and not blocker.get("auto_resolvable"):
+            verdict = VisionVerdict.ESCALATE.value
+            reason = f"Non-resolvable blocker: {blocker.get('type')} — {blocker.get('detail', '')}"
+
         gate.record_step(verdict, img_hash, page_state)
 
         print(f"\n{'=' * 60}")
@@ -2204,14 +2316,32 @@ async def main():
         )
         print(f"{'=' * 60}\n")
 
-        # ---- STOP ----
-        if verdict == "STOP":
-            audit("stop", reason=reason, page_state=page_state)
+        # ---- BLOCKER POLICY ----
+        # WHY: Vision Gate V2 liefert Blocker als strukturierte Daten. Dadurch kann
+        # der Worker automatische Fälle behandeln und harte Fälle explizit eskalieren.
+        if blocker and blocker.get("auto_resolvable"):
+            resolved_inline = await auto_resolve_blocker(
+                blocker, next_action, next_params, gate.total_steps
+            )
+            if resolved_inline:
+                await human_delay(1.0, 2.0)
+                continue
+
+        # ---- STOP / ESCALATE ----
+        if verdict in {VisionVerdict.STOP.value, VisionVerdict.ESCALATE.value}:
+            audit(
+                "stop",
+                reason=reason,
+                page_state=page_state,
+                page_type=page_type,
+                confidence=confidence,
+                blocker=blocker,
+            )
             await save_session("stop_state")
             break
 
         # ---- RETRY ----
-        if verdict == "RETRY":
+        if verdict == VisionVerdict.RETRY.value:
             # Bei RETRY den Selektor als fehlgeschlagen merken
             if next_params.get("selector"):
                 gate.add_failed_selector(next_params["selector"])
@@ -2278,6 +2408,33 @@ async def main():
         except Exception:
             pass
 
+        predicate_before_hash = ""
+        predicate_selector = _selector_for_predicate(next_action, next_params)
+        if next_action in CLICK_ACTIONS or next_action == "type_text":
+            try:
+                predicate_pre = await asyncio.to_thread(
+                    predicate_pre_check, BRIDGE_MCP_URL, predicate_selector
+                )
+                predicate_before_hash = predicate_pre.get("dom_hash", "")
+                audit(
+                    "predicate_pre",
+                    step=gate.total_steps,
+                    action=next_action,
+                    selector=predicate_selector,
+                    ok=predicate_pre.get("ok"),
+                    skipped=predicate_pre.get("skipped"),
+                    visible=predicate_pre.get("visible"),
+                    clickable=predicate_pre.get("clickable"),
+                    not_occluded=predicate_pre.get("not_occluded"),
+                    reason=predicate_pre.get("reason"),
+                )
+                if predicate_selector and not predicate_pre.get("ok"):
+                    gate.add_failed_selector(predicate_selector)
+                    await human_delay(1.0, 2.0)
+                    continue
+            except Exception as e:
+                audit("error", message=f"Predicate pre-check failed: {e}")
+
         try:
             # Scroll-Aktionen
             if next_action in ("scroll_down", "scroll_up"):
@@ -2299,6 +2456,10 @@ async def main():
             elif next_action == "type_text":
                 params = {**next_params, **_tab_params()}
                 await execute_bridge("type_text", params)
+
+            # Explizites Warten — nützlich bei Rate-Limits oder nach Auto-Submits
+            elif next_action == "wait":
+                await human_delay(2.0, 5.0)
 
             # Navigation — IMMER mit exaktem tabId, KEIN Fallback ohne tabId
             elif next_action == "navigate":
@@ -2324,8 +2485,29 @@ async def main():
         # DOM-Verifikation prüft URL + Title — ändert sich irgendeins, war es echter Fortschritt.
         # KONSEQUENZ: mark_dom_progress() setzt no_progress_count zurück → kein vorzeitiger Abbruch.
         await asyncio.sleep(1.0)
+
+        predicate_post = None
+        if next_action in CLICK_ACTIONS or next_action == "type_text":
+            try:
+                predicate_post = await asyncio.to_thread(
+                    predicate_post_check, BRIDGE_MCP_URL, predicate_before_hash
+                )
+                audit(
+                    "predicate_post",
+                    step=gate.total_steps,
+                    action=next_action,
+                    selector=predicate_selector,
+                    changed=predicate_post.get("changed"),
+                    new_hash=predicate_post.get("new_hash", "")[:16],
+                )
+            except Exception as e:
+                audit("error", message=f"Predicate post-check failed: {e}")
+
         dom_check = await dom_verify_change(before_url, before_title)
-        if dom_check.get("changed"):
+        dom_changed = dom_check.get("changed") or bool(
+            predicate_post and predicate_post.get("changed")
+        )
+        if dom_changed:
             # DOM hat sich verändert → echter Fortschritt → no_progress_count zurücksetzen
             gate.mark_dom_progress()
             audit(

--- a/predicate_checks.py
+++ b/predicate_checks.py
@@ -1,0 +1,190 @@
+"""DOM predicate checks used before and after browser mutations.
+
+WHY:
+- Vision alone is not enough to prove that an element is interactable.
+- The worker needs a deterministic DOM-side safety check before click/type and a
+  deterministic DOM hash comparison afterwards.
+
+CONSEQUENCES:
+- Pre-action checks can fail closed when a selector is invisible or occluded.
+- Post-action checks can report real DOM progress even when screenshots look
+  visually similar between survey steps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.request
+from typing import Any
+
+
+def _sha256_text(value: str) -> str:
+    """Returns the SHA-256 hash of normalized body text."""
+
+    return hashlib.sha256((value or "").encode("utf-8")).hexdigest()
+
+
+def _bridge_tool_call(bridge_url: str, tool_name: str, arguments: dict[str, Any]) -> Any:
+    """Executes one JSON-RPC bridge tool call over HTTP.
+
+    WHY:
+    - The worker already talks to the bridge over JSON-RPC.
+    - Keeping a tiny local client here avoids importing the full worker module
+      and prevents circular dependencies between helper files.
+    """
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": arguments},
+    }
+    request = urllib.request.Request(
+        bridge_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        body = json.loads(response.read().decode("utf-8"))
+    if "error" in body:
+        raise RuntimeError(str(body["error"]))
+    result = body.get("result", {})
+
+    # Many bridge tools return a content array with a JSON blob wrapped as text.
+    # This decoder keeps the helper robust across the bridge response variants we
+    # already use in the worker.
+    if isinstance(result, dict) and isinstance(result.get("content"), list):
+        for entry in result["content"]:
+            if isinstance(entry, dict) and isinstance(entry.get("text"), str):
+                text = entry["text"].strip()
+                if not text:
+                    continue
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+    return result
+
+
+def predicate_pre_check(bridge_url, selector) -> dict:
+    """Checks whether a target selector is visible, clickable, and unobscured.
+
+    WHY:
+    - Browser automation must not guess that a selector is ready to receive a
+      click or text input.
+    - The worker also needs the current DOM hash before the mutation so the
+      subsequent post-check can prove whether the page changed.
+
+    CONSEQUENCES:
+    - Missing selectors fail closed with `ok=False`.
+    - Selector-less actions return a skipped result but still include the current
+      DOM hash so the caller can continue with a post-check.
+    """
+
+    selector_literal = json.dumps(selector or "")
+    script = f"""
+    (function() {{
+        var selector = {selector_literal};
+        var bodyText = (document.body && document.body.innerText) || '';
+        if (!selector) {{
+            return {{
+                ok: false,
+                skipped: true,
+                reason: 'missing_selector',
+                visible: false,
+                clickable: false,
+                not_occluded: false,
+                dom_text: bodyText
+            }};
+        }}
+        var el = document.querySelector(selector);
+        if (!el) {{
+            return {{
+                ok: false,
+                skipped: false,
+                reason: 'selector_not_found',
+                visible: false,
+                clickable: false,
+                not_occluded: false,
+                dom_text: bodyText
+            }};
+        }}
+
+        var rect = el.getBoundingClientRect();
+        var style = window.getComputedStyle(el);
+        var visible = !!(
+            rect.width > 0 &&
+            rect.height > 0 &&
+            style.display !== 'none' &&
+            style.visibility !== 'hidden' &&
+            style.opacity !== '0'
+        );
+        var disabled = !!(el.disabled || el.getAttribute('aria-disabled') === 'true');
+        var clickable = visible && !disabled && style.pointerEvents !== 'none';
+        var centerX = Math.max(0, Math.floor(rect.left + rect.width / 2));
+        var centerY = Math.max(0, Math.floor(rect.top + rect.height / 2));
+        var topEl = document.elementFromPoint(centerX, centerY);
+        var notOccluded = !!topEl && (topEl === el || el.contains(topEl) || topEl.contains(el));
+
+        return {{
+            ok: visible && clickable && notOccluded,
+            skipped: false,
+            reason: visible && clickable && notOccluded ? 'ok' : 'predicate_failed',
+            visible: visible,
+            clickable: clickable,
+            not_occluded: notOccluded,
+            dom_text: bodyText,
+            tag_name: el.tagName,
+            element_id: el.id || '',
+            class_name: (el.className || '').toString().slice(0, 120)
+        }};
+    }})();
+    """
+
+    result = _bridge_tool_call(
+        bridge_url,
+        "execute_javascript",
+        {"script": script},
+    )
+
+    if isinstance(result, dict) and "result" in result and isinstance(result["result"], dict):
+        result = result["result"]
+
+    if not isinstance(result, dict):
+        result = {
+            "ok": False,
+            "skipped": False,
+            "reason": "unexpected_bridge_result",
+            "visible": False,
+            "clickable": False,
+            "not_occluded": False,
+            "dom_text": "",
+        }
+
+    dom_text = str(result.pop("dom_text", "") or "")
+    result["dom_hash"] = _sha256_text(dom_text)
+    return result
+
+
+def predicate_post_check(bridge_url, before_hash: str) -> dict:
+    """Calculates the post-action DOM hash and reports whether it changed.
+
+    WHY:
+    - Survey pages often keep the same layout across many question steps.
+    - Comparing the body text hash is a cheap, deterministic signal for whether
+      the action produced actual page-level progress.
+    """
+
+    script = "(function() { return { dom_text: (document.body && document.body.innerText) || '' }; })();"
+    result = _bridge_tool_call(bridge_url, "execute_javascript", {"script": script})
+    if isinstance(result, dict) and "result" in result and isinstance(result["result"], dict):
+        result = result["result"]
+
+    dom_text = ""
+    if isinstance(result, dict):
+        dom_text = str(result.get("dom_text", "") or "")
+
+    new_hash = _sha256_text(dom_text)
+    return {"changed": bool(before_hash and before_hash != new_hash), "new_hash": new_hash}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Pytest bootstrap helpers for flat repository imports.
+
+WHY:
+- The repository is a script-based layout instead of an installed Python package.
+- Pytest can collect tests with `tests/` as the first import root, which would
+  hide modules that live directly at the repository root.
+
+CONSEQUENCES:
+- The repository root is inserted into `sys.path` once during collection.
+- Targeted commands like `pytest tests/test_vision_contract.py -v` work without
+  extra shell prefixes or ad-hoc environment variables.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Resolve the repository root relative to this file so imports stay stable even
+# when pytest is launched from a different working directory.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# Insert the repository root only once to keep import resolution deterministic
+# while avoiding duplicate path entries in long-running test sessions.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_vision_contract.py
+++ b/tests/test_vision_contract.py
@@ -1,0 +1,153 @@
+"""Pytest coverage for the Vision Gate V2 response contract.
+
+WHY:
+- The new perception layer depends on strict schema parsing and deterministic
+  worker policy enforcement.
+- These tests lock the contract before the worker executes real browser actions.
+
+CONSEQUENCES:
+- Regressions in JSON parsing, fallback parsing, or confidence/blocker policy
+  are caught with a fast targeted pytest run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from vision_contract import VisionVerdict, parse_vision_response
+
+
+# Import the worker module by path so the test remains stable even though the
+# repository is currently a flat script-based layout rather than an installed
+# package.
+MODULE_PATH = Path(__file__).resolve().parents[1] / "heypiggy_vision_worker.py"
+SPEC = importlib.util.spec_from_file_location("heypiggy_vision_worker", MODULE_PATH)
+worker = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(worker)
+
+
+def test_parse_vision_response_accepts_valid_json_contract():
+    """A fully valid JSON payload should map directly into the strict model."""
+
+    raw_text = """
+    {
+      "verdict": "PROCEED",
+      "confidence": 0.91,
+      "page_type": "survey_question",
+      "blocker": null,
+      "next_action": {
+        "type": "click",
+        "target": "selector:#survey-65076903",
+        "value": ""
+      },
+      "dom_hash": "abc123def456",
+      "reasoning": "The survey question is visible and ready for one click."
+    }
+    """
+
+    response = parse_vision_response(raw_text)
+
+    assert response.verdict is VisionVerdict.PROCEED
+    assert response.confidence == 0.91
+    assert response.page_type == "survey_question"
+    assert response.blocker is None
+    assert response.next_action.type == "click"
+    assert response.next_action.target == "selector:#survey-65076903"
+    assert response.dom_hash == "abc123def456"
+
+
+def test_parse_vision_response_falls_back_to_regex_for_malformed_json():
+    """Malformed JSON should still salvage a safe structured response."""
+
+    raw_text = (
+        'verdict: RETRY confidence: 0.73 page_type: survey_list '
+        'reasoning: Modal still covers the survey list next_action: wait target: modal value: loading '
+        'blocker_type: modal blocker_detail: consent banner auto_resolvable: true'
+    )
+
+    response = parse_vision_response(raw_text)
+
+    assert response.verdict is VisionVerdict.RETRY
+    assert response.confidence == 0.73
+    assert response.page_type == "survey_list"
+    assert response.blocker is not None
+    assert response.blocker.type == "modal"
+    assert response.blocker.auto_resolvable is True
+    assert response.next_action.type == "wait"
+
+
+def test_parse_vision_response_returns_retry_for_total_garbage():
+    """Completely unusable model text must degrade into a safe RETRY response."""
+
+    response = parse_vision_response("totally unusable output without any contract fields")
+
+    assert response.verdict is VisionVerdict.RETRY
+    assert response.page_type == "unknown"
+    assert response.next_action.type == "none"
+
+
+def test_low_confidence_policy_forces_retry_even_for_valid_json():
+    """Valid JSON must still fail closed when the model is not confident enough."""
+
+    response = parse_vision_response(
+        """
+        {
+          "verdict": "PROCEED",
+          "confidence": 0.42,
+          "page_type": "survey_question",
+          "blocker": null,
+          "next_action": {"type": "click", "target": "selector:#go", "value": ""},
+          "dom_hash": "hash-low-confidence",
+          "reasoning": "I think the button is probably correct."
+        }
+        """
+    )
+
+    guarded = worker._apply_vision_response_policy(response)
+
+    assert guarded.verdict is VisionVerdict.RETRY
+    assert guarded.next_action.type == "none"
+    assert "Low-confidence" in guarded.reasoning
+
+
+def test_blocker_policy_distinguishes_auto_resolvable_from_escalation():
+    """Worker policy should preserve auto-resolvable blockers and escalate the rest."""
+
+    auto_response = parse_vision_response(
+        """
+        {
+          "verdict": "PROCEED",
+          "confidence": 0.88,
+          "page_type": "survey_list",
+          "blocker": {"type": "modal", "detail": "Cookie banner", "auto_resolvable": true},
+          "next_action": {"type": "click", "target": "selector:#accept-cookies", "value": ""},
+          "dom_hash": "modal-hash",
+          "reasoning": "A dismissible modal blocks the list."
+        }
+        """
+    )
+    manual_response = parse_vision_response(
+        """
+        {
+          "verdict": "PROCEED",
+          "confidence": 0.88,
+          "page_type": "captcha",
+          "blocker": {"type": "captcha", "detail": "Challenge page", "auto_resolvable": false},
+          "next_action": {"type": "none", "target": "", "value": ""},
+          "dom_hash": "captcha-hash",
+          "reasoning": "A captcha blocks progress."
+        }
+        """
+    )
+
+    guarded_auto = worker._apply_vision_response_policy(auto_response)
+    guarded_manual = worker._apply_vision_response_policy(manual_response)
+
+    assert guarded_auto.verdict is VisionVerdict.PROCEED
+    assert guarded_auto.blocker is not None
+    assert guarded_auto.blocker.auto_resolvable is True
+    assert guarded_manual.verdict is VisionVerdict.ESCALATE
+    assert guarded_manual.blocker is not None
+    assert guarded_manual.blocker.auto_resolvable is False

--- a/vision_contract.py
+++ b/vision_contract.py
@@ -1,0 +1,435 @@
+"""Strict schema contract helpers for Vision Gate V2.
+
+This module centralizes the typed contract between the screenshot-based vision
+model output and the worker's decision loop.
+
+WHY:
+- The previous worker logic accepted loosely formatted JSON and then inferred
+  important control-flow fields from ad-hoc string parsing.
+- A single contract module makes the prompt, parser, and tests agree on one
+  canonical shape.
+- The worker can now fail closed with a deterministic RETRY response instead of
+  branching on partially parsed free-form text.
+
+CONSEQUENCES:
+- All vision responses are normalized into the same `VisionResponse` object.
+- Fallback parsing remains tolerant enough for production drift, but the worker
+  always consumes the strict typed structure afterwards.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+# The verdict enum is intentionally string-backed so JSON payloads from the
+# model can be passed through without additional serialization glue.
+class VisionVerdict(str, Enum):
+    """Canonical decision outcomes for the vision gate."""
+
+    PROCEED = "PROCEED"
+    STOP = "STOP"
+    RETRY = "RETRY"
+    ESCALATE = "ESCALATE"
+
+
+@dataclass(slots=True)
+class BlockerInfo:
+    """Structured description of a blocker detected by the vision layer.
+
+    WHY:
+    - Blockers need a dedicated shape so the worker can distinguish between a
+      captcha, a dismissible modal, an auth gate, or a rate-limit banner.
+    - `auto_resolvable` gives the execution loop a deterministic branch instead
+      of guessing whether an obstacle should be handled automatically.
+    """
+
+    type: Literal["captcha", "modal", "auth", "rate_limit"]
+    detail: str
+    auto_resolvable: bool
+
+
+@dataclass(slots=True)
+class NextAction:
+    """Single follow-up action proposed by the vision layer.
+
+    WHY:
+    - The worker should execute one small, explicit action at a time.
+    - `target` and `value` stay generic enough to support click, type, scroll,
+      wait, and no-op behaviors without re-introducing free-form parsing.
+    """
+
+    type: Literal["click", "type", "scroll", "wait", "none"]
+    target: str = ""
+    value: str = ""
+
+
+class VisionResponse(BaseModel):
+    """Validated response envelope returned to the worker loop.
+
+    NOTE:
+    - Pydantic is used for robust field coercion and nested validation.
+    - Range checks that need graceful fallback behavior are enforced inside the
+      parser before model construction so malformed payloads can degrade into a
+      deterministic RETRY response instead of raising out of the loop.
+    """
+
+    verdict: VisionVerdict
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    page_type: str
+    blocker: BlockerInfo | None = None
+    next_action: NextAction
+    dom_hash: str = ""
+    reasoning: str = ""
+
+
+# Action aliases let the parser tolerate legacy outputs from older prompts while
+# still normalizing them into the new generic action schema.
+_ACTION_ALIAS_MAP = {
+    "click": "click",
+    "click_element": "click",
+    "click_ref": "click",
+    "ghost_click": "click",
+    "vision_click": "click",
+    "click_coordinates": "click",
+    "type": "type",
+    "type_text": "type",
+    "scroll": "scroll",
+    "scroll_down": "scroll",
+    "scroll_up": "scroll",
+    "wait": "wait",
+    "none": "none",
+    "navigate": "wait",
+    "keyboard": "click",
+}
+
+
+def _strip_code_fences(raw_text: str) -> str:
+    """Removes optional markdown fences before JSON parsing.
+
+    WHY:
+    - The prompt demands JSON-only output, but real model responses can still
+      occasionally wrap the payload in triple backticks.
+    - Removing the wrapper keeps the parser resilient without relaxing the
+      worker's strict typed contract.
+    """
+
+    text = (raw_text or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"\s*```$", "", text)
+    return text.strip()
+
+
+def _extract_first_json_object(text: str) -> str | None:
+    """Extracts the first balanced JSON object from a noisy response body."""
+
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape = False
+    for index, char in enumerate(text[start:], start=start):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    return None
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Coerces mixed boolean-like values into an actual bool."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "1"}:
+            return True
+        if normalized in {"false", "no", "0"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _coerce_confidence(value: Any, default: float = 0.0) -> float:
+    """Converts confidence to a bounded float.
+
+    WHY:
+    - The contract promises a 0.0-1.0 confidence value.
+    - Bounding the value here avoids model validation errors and keeps the
+      fallback path deterministic.
+    """
+
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, min(1.0, confidence))
+
+
+def _normalize_next_action(candidate: Any) -> NextAction:
+    """Normalizes new-schema or legacy action shapes into `NextAction`."""
+
+    if isinstance(candidate, NextAction):
+        return candidate
+
+    if is_dataclass(candidate):
+        candidate = asdict(candidate)
+
+    if isinstance(candidate, dict):
+        raw_type = str(candidate.get("type", "none") or "none").strip().lower()
+        target = str(candidate.get("target", "") or "")
+        value = str(candidate.get("value", "") or "")
+    else:
+        raw_type = str(candidate or "none").strip().lower()
+        target = ""
+        value = ""
+
+    normalized_type = _ACTION_ALIAS_MAP.get(raw_type, "none")
+    if normalized_type == "click" and not target and isinstance(candidate, dict):
+        target = str(
+            candidate.get("selector")
+            or candidate.get("ref")
+            or candidate.get("description")
+            or candidate.get("coordinates")
+            or ""
+        )
+    if normalized_type == "type" and not value and isinstance(candidate, dict):
+        value = str(candidate.get("text") or candidate.get("value") or "")
+        if not target:
+            target = str(candidate.get("selector") or "")
+    if normalized_type == "scroll" and not value and isinstance(candidate, dict):
+        value = str(candidate.get("direction") or candidate.get("value") or "")
+    return NextAction(type=normalized_type, target=target, value=value)
+
+
+def _normalize_blocker(candidate: Any) -> BlockerInfo | None:
+    """Normalizes blocker payloads into the strict blocker dataclass."""
+
+    if candidate in (None, "", {}):
+        return None
+    if isinstance(candidate, BlockerInfo):
+        return candidate
+    if is_dataclass(candidate):
+        candidate = asdict(candidate)
+    if not isinstance(candidate, dict):
+        return None
+
+    blocker_type = str(candidate.get("type", "") or "").strip().lower()
+    if blocker_type not in {"captcha", "modal", "auth", "rate_limit"}:
+        return None
+
+    return BlockerInfo(
+        type=blocker_type,
+        detail=str(candidate.get("detail", "") or ""),
+        auto_resolvable=_coerce_bool(candidate.get("auto_resolvable"), default=False),
+    )
+
+
+def _candidate_from_regex(raw_text: str) -> dict[str, Any]:
+    """Extracts the most important fields from malformed non-JSON text.
+
+    WHY:
+    - Production model outputs occasionally drift when rate-limited or when the
+      model partially follows the prompt.
+    - Regex extraction salvages enough structure for safe retries without ever
+      pretending the payload was fully valid JSON.
+    """
+
+    text = raw_text or ""
+    verdict_match = re.search(r"\b(PROCEED|STOP|RETRY|ESCALATE)\b", text, re.IGNORECASE)
+    confidence_match = re.search(r"confidence\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)", text, re.IGNORECASE)
+    page_match = re.search(r"page(?:_state|_type)?\s*[:=]\s*[\"']?([a-z_]+)", text, re.IGNORECASE)
+    dom_hash_match = re.search(r"dom_hash\s*[:=]\s*[\"']?([a-f0-9]{6,64})", text, re.IGNORECASE)
+    reasoning_match = re.search(
+        r"(?:reason|reasoning)\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    blocker_match = re.search(
+        r"blocker(?:_type)?\s*[:=]\s*[\"']?(captcha|modal|auth|rate_limit)",
+        text,
+        re.IGNORECASE,
+    )
+    auto_resolvable_match = re.search(
+        r"auto_resolvable\s*[:=]\s*(true|false|yes|no|1|0)",
+        text,
+        re.IGNORECASE,
+    )
+    blocker_detail_match = re.search(
+        r"blocker_detail\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    action_type_match = re.search(
+        r"next_action(?:\.type)?\s*[:=]\s*[\"']?([a-z_]+)",
+        text,
+        re.IGNORECASE,
+    )
+    action_target_match = re.search(
+        r"target\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    action_value_match = re.search(
+        r"value\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    candidate: dict[str, Any] = {
+        "verdict": (verdict_match.group(1).upper() if verdict_match else "RETRY"),
+        "confidence": (
+            _coerce_confidence(confidence_match.group(1), default=0.0)
+            if confidence_match
+            else 0.0
+        ),
+        "page_type": (page_match.group(1).lower() if page_match else "unknown"),
+        "dom_hash": (dom_hash_match.group(1) if dom_hash_match else ""),
+        "reasoning": (
+            reasoning_match.group(1).strip() if reasoning_match else text.strip()[:300]
+        ),
+        "next_action": {
+            "type": (action_type_match.group(1).lower() if action_type_match else "none"),
+            "target": (action_target_match.group(1).strip() if action_target_match else ""),
+            "value": (action_value_match.group(1).strip() if action_value_match else ""),
+        },
+    }
+
+    if blocker_match:
+        candidate["blocker"] = {
+            "type": blocker_match.group(1).lower(),
+            "detail": (
+                blocker_detail_match.group(1).strip() if blocker_detail_match else ""
+            ),
+            "auto_resolvable": _coerce_bool(
+                auto_resolvable_match.group(1) if auto_resolvable_match else False,
+                default=False,
+            ),
+        }
+
+    return candidate
+
+
+def _normalize_candidate(candidate: dict[str, Any], fallback_reasoning: str) -> VisionResponse:
+    """Builds a strict `VisionResponse` from a partially trusted dictionary."""
+
+    verdict = str(candidate.get("verdict", "RETRY") or "RETRY").upper()
+    if verdict not in VisionVerdict.__members__:
+        verdict = VisionVerdict.RETRY.value
+
+    page_type = str(
+        candidate.get("page_type")
+        or candidate.get("page_state")
+        or "unknown"
+    ).strip().lower()
+    if page_type not in {
+        "login",
+        "survey_list",
+        "survey_question",
+        "survey_complete",
+        "captcha",
+        "unknown",
+    }:
+        page_type = "unknown"
+
+    reasoning = str(
+        candidate.get("reasoning") or candidate.get("reason") or fallback_reasoning
+    ).strip()
+    blocker = _normalize_blocker(candidate.get("blocker"))
+
+    next_action_source = candidate.get("next_action")
+    if next_action_source is None and "next_params" in candidate:
+        next_action_source = {
+            "type": candidate.get("next_action", "none"),
+            **(candidate.get("next_params") or {}),
+        }
+    if next_action_source is None:
+        next_action_source = candidate.get("next_action_type") or "none"
+
+    return VisionResponse(
+        verdict=VisionVerdict(verdict),
+        confidence=_coerce_confidence(candidate.get("confidence"), default=0.0),
+        page_type=page_type,
+        blocker=blocker,
+        next_action=_normalize_next_action(next_action_source),
+        dom_hash=str(candidate.get("dom_hash", "") or ""),
+        reasoning=reasoning,
+    )
+
+
+def parse_vision_response(raw_text: str) -> VisionResponse:
+    """Parses raw model text into the strict vision response contract.
+
+    Parsing strategy:
+    1. Try direct JSON from the raw text.
+    2. If that fails, extract the first balanced JSON object from noisy text.
+    3. If JSON still fails, salvage core fields with regex extraction.
+    4. On total failure, return a safe RETRY response.
+
+    WHY:
+    - The worker must never trust unconstrained model text directly.
+    - The parser must also never crash the main loop over malformed output.
+
+    CONSEQUENCES:
+    - All caller code can operate on one typed object.
+    - The failure path is deterministic and fail-closed.
+    """
+
+    cleaned = _strip_code_fences(raw_text)
+    fallback_reasoning = cleaned[:300] if cleaned else "Vision output missing or unparsable."
+
+    json_candidates = [cleaned]
+    extracted = _extract_first_json_object(cleaned)
+    if extracted and extracted != cleaned:
+        json_candidates.append(extracted)
+
+    for candidate_text in json_candidates:
+        if not candidate_text:
+            continue
+        try:
+            candidate = json.loads(candidate_text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            try:
+                return _normalize_candidate(candidate, fallback_reasoning)
+            except Exception:
+                continue
+
+    try:
+        regex_candidate = _candidate_from_regex(cleaned)
+        return _normalize_candidate(regex_candidate, fallback_reasoning)
+    except Exception:
+        return VisionResponse(
+            verdict=VisionVerdict.RETRY,
+            confidence=0.0,
+            page_type="unknown",
+            blocker=None,
+            next_action=NextAction(type="none", target="", value=""),
+            dom_hash="",
+            reasoning="Vision output missing or unparsable.",
+        )

--- a/vision_prompt.py
+++ b/vision_prompt.py
@@ -1,0 +1,126 @@
+"""Prompt builder for the strict Vision Gate V2 JSON contract.
+
+WHY:
+- The worker must ask the model for one exact machine-readable payload.
+- The prompt now embeds the canonical schema so the model sees the contract
+  inline instead of inferring fields from prose.
+
+CONSEQUENCES:
+- The caller can expect one strict JSON document.
+- The parser can stay simple and fail closed when the model drifts.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def build_vision_prompt(action_desc: str, expected_result: str, dom_snapshot: str) -> str:
+    """Builds the schema-constrained prompt for the screenshot vision call.
+
+    WHY:
+    - The previous free-form prompt allowed commentary, markdown fences, and
+      tool-specific action drift.
+    - Embedding the full JSON schema makes the desired contract explicit and
+      keeps the output aligned with the parser and tests.
+
+    CONSEQUENCES:
+    - The model is instructed to emit JSON only.
+    - The worker can validate the response deterministically.
+    """
+
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "verdict",
+            "confidence",
+            "page_type",
+            "blocker",
+            "next_action",
+            "dom_hash",
+            "reasoning",
+        ],
+        "properties": {
+            "verdict": {
+                "type": "string",
+                "enum": ["PROCEED", "STOP", "RETRY", "ESCALATE"],
+            },
+            "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            "page_type": {
+                "type": "string",
+                "enum": [
+                    "login",
+                    "survey_list",
+                    "survey_question",
+                    "survey_complete",
+                    "captcha",
+                    "unknown",
+                ],
+            },
+            "blocker": {
+                "type": ["object", "null"],
+                "additionalProperties": False,
+                "required": ["type", "detail", "auto_resolvable"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["captcha", "modal", "auth", "rate_limit"],
+                    },
+                    "detail": {"type": "string"},
+                    "auto_resolvable": {"type": "boolean"},
+                },
+            },
+            "next_action": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["type", "target", "value"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["click", "type", "scroll", "wait", "none"],
+                    },
+                    "target": {"type": "string"},
+                    "value": {"type": "string"},
+                },
+            },
+            "dom_hash": {"type": "string"},
+            "reasoning": {"type": "string"},
+        },
+    }
+
+    pretty_schema = json.dumps(schema, ensure_ascii=False, indent=2)
+    dom_text = dom_snapshot.strip() if dom_snapshot.strip() else "<no_dom_snapshot>"
+
+    return f"""You are the OpenSIN Vision Gate controller.
+Analyze the screenshot together with the DOM snapshot and return exactly one JSON object.
+Do not return markdown. Do not wrap the JSON in backticks. Do not include explanations before or after the JSON.
+If you are uncertain, return verdict RETRY instead of guessing.
+
+Action description: {action_desc}
+Expected result: {expected_result}
+
+DOM snapshot:
+{dom_text}
+
+Rules for next_action:
+- type=click: use target to describe the click target. Prefer selector:#css-selector, ref:@e12, text:Visible Label, or coords:123,456.
+- type=type: use target as selector:#css-selector and value as the text to enter. Use <EMAIL> or <PASSWORD> placeholders instead of secrets.
+- type=scroll: use value as down or up.
+- type=wait: use value as a short reason such as loading or rate_limit.
+- type=none: leave target and value as empty strings.
+
+Rules for blockers:
+- blocker=null when no blocker is present.
+- blocker.type=captcha for captcha or challenge pages.
+- blocker.type=modal for consent banners, overlays, cookie banners, or dismissible dialogs.
+- blocker.type=auth for login/session barriers.
+- blocker.type=rate_limit for cooldown banners or retry-later states.
+- auto_resolvable=true only when the worker can realistically dismiss or wait through the blocker automatically.
+
+The DOM hash must reflect the page state you observe. If no hash is visible in the DOM snapshot, return an empty string.
+Reasoning must be concise and factual.
+
+Return JSON that matches this exact schema:
+{pretty_schema}
+"""


### PR DESCRIPTION
## Summary
- replace the free-form vision response flow with a strict JSON contract, schema-driven prompt builder, and safe parser fallbacks
- add DOM predicate pre/post checks plus blocker/confidence policy enforcement around click and type actions in the worker loop
- cover the new contract behavior with targeted pytest coverage and keep direct pytest invocation stable via test import bootstrap

## Validation
- pytest tests/test_vision_contract.py -v
- pytest tests/test_heypiggy_vision_worker.py -v