### PR TITLE
[ALPHA] integrate FSM + Vision V2 + Sitepack + runtime hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+.serena/
+checkpoint.json

--- a/agent_state_machine.py
+++ b/agent_state_machine.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Typed finite state machine for the OpenSIN HeyPiggy worker.
+
+WHY THIS MODULE EXISTS:
+- The worker used to move through a mostly linear script with ad-hoc branching.
+- That shape makes it hard to prove which phase the worker is currently in.
+- It also makes fail-safe handling, escalation, and checkpointing inconsistent.
+
+WHAT THIS MODULE PROVIDES:
+- A strongly typed `AgentState` enum for every major worker phase.
+- A `StepContext` dataclass that carries the live FSM metadata.
+- A strict transition table that blocks invalid state jumps.
+- Shared fail-safe and escalation helpers that always checkpoint context.
+
+CONSEQUENCES:
+- The worker can now reason about its own phase explicitly.
+- Invalid phase jumps fail loudly instead of silently corrupting control flow.
+- Debugging and recovery become easier because every transition is logged as JSON.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import sys
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+
+# WHY: A stable checkpoint filename makes it trivial for operators, tests, and
+# recovery tooling to know where the latest context snapshot will be written.
+CHECKPOINT_PATH: Final[Path] = Path("checkpoint.json")
+
+
+class AgentState(enum.Enum):
+    """
+    Typed list of all allowed high-level worker phases.
+
+    WHY THIS ENUM EXISTS:
+    - Stringly typed phases are easy to mistype and hard to validate.
+    - An enum gives us one canonical vocabulary for orchestration, tests,
+      structured logging, and future recovery tooling.
+
+    CONSEQUENCES:
+    - Every transition is explicit and machine-checkable.
+    - Tests can assert exact states instead of brittle free-form strings.
+    """
+
+    INIT = "INIT"
+    PREFLIGHT = "PREFLIGHT"
+    ACQUIRE_SESSION = "ACQUIRE_SESSION"
+    ASSESS_PAGE = "ASSESS_PAGE"
+    RESOLVE_BLOCKERS = "RESOLVE_BLOCKERS"
+    AUTHENTICATE = "AUTHENTICATE"
+    ONBOARD = "ONBOARD"
+    DISCOVER_WORK = "DISCOVER_WORK"
+    SELECT_TASK = "SELECT_TASK"
+    ENTER_TASK = "ENTER_TASK"
+    EXECUTE_TASK_LOOP = "EXECUTE_TASK_LOOP"
+    VALIDATE_OUTCOME = "VALIDATE_OUTCOME"
+    RECORD_RESULT = "RECORD_RESULT"
+    COMPLETE = "COMPLETE"
+    FAIL_SAFE = "FAIL_SAFE"
+    ESCALATE = "ESCALATE"
+
+
+class IllegalTransitionError(Exception):
+    """
+    Raised when the caller attempts a state jump not permitted by the FSM.
+
+    WHY THIS CUSTOM EXCEPTION EXISTS:
+    - A domain-specific exception makes illegal control-flow bugs obvious.
+    - Catchers can distinguish FSM violations from unrelated runtime failures.
+    """
+
+
+@dataclass
+class StepContext:
+    """
+    Runtime context that travels together with the worker FSM.
+
+    WHY THESE FIELDS EXIST:
+    - `state` tells us the current phase.
+    - `step_index` counts successful transitions so operators can reason about
+      progress and loop length.
+    - `max_steps` gives the controller a hard safety ceiling.
+    - `no_progress_counter` tracks repeated iterations with no visible progress.
+    - `last_page_fingerprint` lets the worker compare current vs previous page.
+    - `run_id` provides a globally unique execution identifier.
+    - `task_url` remembers which survey/task is currently being processed.
+    - `earnings_so_far` stores accumulated outcome value for reporting.
+
+    CONSEQUENCES:
+    - The worker can checkpoint enough data to recover or debug meaningfully.
+    - Tests can build minimal contexts while still exercising real behavior.
+    """
+
+    state: AgentState
+    step_index: int
+    max_steps: int = 120
+    no_progress_counter: int = 0
+    last_page_fingerprint: str = ""
+    run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    task_url: str | None = None
+    earnings_so_far: float = 0.0
+
+
+# WHY: Keeping the transition table as module-level data makes the legal phase
+# graph visible, testable, and reusable from multiple worker entry points.
+TRANSITION_TABLE: dict[AgentState, list[AgentState]] = {
+    AgentState.INIT: [
+        AgentState.PREFLIGHT,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.PREFLIGHT: [
+        AgentState.ACQUIRE_SESSION,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.ACQUIRE_SESSION: [
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.ASSESS_PAGE: [
+        AgentState.RESOLVE_BLOCKERS,
+        AgentState.AUTHENTICATE,
+        AgentState.ONBOARD,
+        AgentState.DISCOVER_WORK,
+        AgentState.SELECT_TASK,
+        AgentState.ENTER_TASK,
+        AgentState.EXECUTE_TASK_LOOP,
+        AgentState.VALIDATE_OUTCOME,
+        AgentState.RECORD_RESULT,
+        AgentState.COMPLETE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.RESOLVE_BLOCKERS: [
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.AUTHENTICATE: [
+        AgentState.ONBOARD,
+        AgentState.DISCOVER_WORK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.ONBOARD: [
+        AgentState.DISCOVER_WORK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.DISCOVER_WORK: [
+        AgentState.SELECT_TASK,
+        AgentState.COMPLETE,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.SELECT_TASK: [
+        AgentState.ENTER_TASK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.ENTER_TASK: [
+        AgentState.EXECUTE_TASK_LOOP,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.EXECUTE_TASK_LOOP: [
+        AgentState.EXECUTE_TASK_LOOP,
+        AgentState.VALIDATE_OUTCOME,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.VALIDATE_OUTCOME: [
+        AgentState.RECORD_RESULT,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.RECORD_RESULT: [
+        AgentState.COMPLETE,
+        AgentState.DISCOVER_WORK,
+        AgentState.ASSESS_PAGE,
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.COMPLETE: [
+        AgentState.FAIL_SAFE,
+        AgentState.ESCALATE,
+    ],
+    AgentState.FAIL_SAFE: [
+        AgentState.ESCALATE,
+    ],
+    AgentState.ESCALATE: [],
+}
+
+
+def _context_to_json_dict(ctx: StepContext) -> dict[str, object]:
+    """
+    Convert the dataclass into JSON-safe primitives.
+
+    WHY THIS HELPER EXISTS:
+    - `asdict()` keeps the conversion logic centralized.
+    - The enum must be serialized as its readable name instead of a Python object.
+
+    CONSEQUENCES:
+    - Checkpoints and logs become deterministic and easy to inspect.
+    """
+
+    payload = asdict(ctx)
+    payload["state"] = ctx.state.name
+    return payload
+
+
+def _write_checkpoint(ctx: StepContext, reason: str, exception: Exception | None = None) -> Path:
+    """
+    Persist the current FSM context to `checkpoint.json`.
+
+    WHY THIS HELPER EXISTS:
+    - Both fail-safe and escalation must checkpoint identically.
+    - Centralizing the write logic avoids drift between the two exit paths.
+
+    CONSEQUENCES:
+    - Operators can always inspect one canonical recovery file.
+    """
+
+    checkpoint_payload = {
+        **_context_to_json_dict(ctx),
+        "reason": reason,
+        "exception": repr(exception) if exception is not None else None,
+        "checkpoint_timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    CHECKPOINT_PATH.write_text(
+        json.dumps(checkpoint_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return CHECKPOINT_PATH
+
+
+def _log_transition(ctx: StepContext, previous_state: AgentState, new_state: AgentState, reason: str) -> None:
+    """
+    Emit one structured JSON log entry for a successful transition.
+
+    WHY THIS HELPER EXISTS:
+    - Transition logging must be consistent across all callers.
+    - JSON logs are easier to ingest into audit tooling than free-form text.
+
+    CONSEQUENCES:
+    - Every accepted state change can be correlated by `run_id` and step index.
+    """
+
+    log_entry = {
+        "event": "state_transition",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "run_id": ctx.run_id,
+        "step_index": ctx.step_index,
+        "from_state": previous_state.name,
+        "to_state": new_state.name,
+        "reason": reason,
+        "task_url": ctx.task_url,
+        "no_progress_counter": ctx.no_progress_counter,
+        "earnings_so_far": ctx.earnings_so_far,
+    }
+    print(json.dumps(log_entry, ensure_ascii=False))
+
+
+def step_context_advance(ctx: StepContext, new_state: AgentState, reason: str) -> StepContext:
+    """
+    Validate and perform one FSM transition.
+
+    WHY THIS FUNCTION EXISTS:
+    - Callers should never mutate `ctx.state` directly because that bypasses the
+      legal transition rules and destroys our audit trail.
+    - This helper is the single gatekeeper for all normal phase changes.
+
+    CONSEQUENCES:
+    - Illegal transitions raise `IllegalTransitionError` immediately.
+    - Successful transitions increment the step index and emit structured JSON.
+    """
+
+    previous_state = ctx.state
+    allowed_next_states = TRANSITION_TABLE.get(previous_state, [])
+    if new_state not in allowed_next_states:
+        allowed_names = [state.name for state in allowed_next_states]
+        raise IllegalTransitionError(
+            f"Illegal transition {previous_state.name} -> {new_state.name}. "
+            f"Allowed: {allowed_names}"
+        )
+
+    _log_transition(ctx, previous_state, new_state, reason)
+    ctx.state = new_state
+    ctx.step_index += 1
+    return ctx
+
+
+def fail_safe(ctx: StepContext, reason: str) -> None:
+    """
+    Enter the fail-safe terminal path, checkpoint context, and exit cleanly.
+
+    WHY THIS FUNCTION EXISTS:
+    - Some situations are recoverable enough that we want a controlled stop
+      instead of a hard crash.
+    - We still need a checkpoint and a clear human-readable summary.
+
+    CONSEQUENCES:
+    - The process exits with code `0` after persisting the latest context.
+    - If the caller was not already in `FAIL_SAFE`, we try to advance into it.
+    """
+
+    if ctx.state != AgentState.FAIL_SAFE:
+        step_context_advance(ctx, AgentState.FAIL_SAFE, reason)
+
+    checkpoint_path = _write_checkpoint(ctx, reason)
+    summary = {
+        "event": "fail_safe",
+        "run_id": ctx.run_id,
+        "state": ctx.state.name,
+        "step_index": ctx.step_index,
+        "reason": reason,
+        "checkpoint": str(checkpoint_path),
+    }
+    print(json.dumps(summary, ensure_ascii=False))
+    raise SystemExit(0)
+
+
+def escalate(ctx: StepContext, reason: str, exception: Exception | None = None) -> None:
+    """
+    Enter the escalation terminal path, checkpoint context, and exit with error.
+
+    WHY THIS FUNCTION EXISTS:
+    - Retry exhaustion or unrecoverable contradictions must be surfaced loudly.
+    - Operators need both stderr visibility and an on-disk checkpoint snapshot.
+
+    CONSEQUENCES:
+    - The process exits with code `1` after printing `ESCALATE` to stderr.
+    - The optional exception is preserved in the checkpoint for later debugging.
+    """
+
+    if ctx.state != AgentState.ESCALATE:
+        step_context_advance(ctx, AgentState.ESCALATE, reason)
+
+    checkpoint_path = _write_checkpoint(ctx, reason, exception=exception)
+    escalation_summary = {
+        "event": "escalate",
+        "run_id": ctx.run_id,
+        "state": ctx.state.name,
+        "step_index": ctx.step_index,
+        "reason": reason,
+        "exception": repr(exception) if exception is not None else None,
+        "checkpoint": str(checkpoint_path),
+    }
+    print("ESCALATE", file=sys.stderr)
+    print(json.dumps(escalation_summary, ensure_ascii=False), file=sys.stderr)
+    raise SystemExit(1)

--- a/heypiggy_vision_worker.py
+++ b/heypiggy_vision_worker.py
@@ -332,6 +332,12 @@ def collect_opencode_text(stdout: bytes, stderr: bytes = b"") -> str:
             continue
         if event.get("type") == "text":
             full_text += event.get("part", {}).get("text", "")
+        elif event.get("type") == "error":
+            error_data = event.get("error", {}) or {}
+            error_message = error_data.get("message", "")
+            provider_id = error_data.get("data", {}).get("providerID", "")
+            if provider_id or error_message:
+                full_text += f" {provider_id} {error_message}".strip()
     return full_text.strip()
 
 
@@ -350,6 +356,10 @@ def detect_vision_auth_failure(raw_text: str) -> str | None:
         return "invalid authentication credentials"
     if "authentication credentials" in lowered and "invalid" in lowered:
         return "invalid authentication credentials"
+    if "api key is missing" in lowered:
+        return "google api key is missing"
+    if "configuration is invalid" in lowered and "plugins" in lowered:
+        return "configuration invalid: plugins key"
 
     health_markers = (
         "vision health failure",
@@ -386,7 +396,7 @@ async def run_vision_model(
     nutzen, damit Auth-Fehler zentral erkannt und fail-closed behandelt werden.
     CONSEQUENCES: Gibt strukturierte Resultate mit `ok` und `auth_failure` zurück.
     """
-    cli_timeout = max(15, min(timeout, 25))
+    cli_timeout = max(20, min(timeout, 45))
     cmd = [
         "timeout",
         str(cli_timeout),
@@ -1297,11 +1307,26 @@ def _next_action_to_worker_command(next_action: NextAction) -> tuple[str, dict]:
     target = (next_action.target or "").strip()
     value = (next_action.value or "").strip()
 
+    def _extract_accessibility_ref(raw_target: str) -> str:
+        """
+        Extrahiert eine Accessibility-Referenz wie `@e19` aus freien Zielstrings.
+        WHY: Das Vision-Modell liefert nicht immer sauber `ref:@e19`, sondern oft
+             Formen wie `textbox @e19`. Diese müssen trotzdem in den ref-basierten
+             Bridge-Pfad geroutet werden.
+        CONSEQUENCES: Click- und Type-Aktionen verstehen sowohl explizite `ref:`-
+                      Targets als auch lose Accessibility-Referenzen.
+        """
+        match = re.search(r"(@e\d+)", raw_target or "", flags=re.IGNORECASE)
+        return match.group(1) if match else ""
+
     if action_type == "click":
         if target.startswith("selector:"):
             return "click_element", {"selector": target.split(":", 1)[1].strip()}
         if target.startswith("ref:"):
             return "click_ref", {"ref": target.split(":", 1)[1].strip()}
+        inferred_ref = _extract_accessibility_ref(target)
+        if inferred_ref:
+            return "click_ref", {"ref": inferred_ref}
         if target.startswith("text:"):
             return "vision_click", {"description": target.split(":", 1)[1].strip()}
         if target.startswith("coords:"):
@@ -1319,6 +1344,15 @@ def _next_action_to_worker_command(next_action: NextAction) -> tuple[str, dict]:
         return "none", {}
 
     if action_type == "type":
+        inferred_ref = ""
+        if target.startswith("ref:"):
+            inferred_ref = target.split(":", 1)[1].strip()
+        else:
+            inferred_ref = _extract_accessibility_ref(target)
+
+        if inferred_ref:
+            return "type_text", {"ref": inferred_ref, "text": value}
+
         selector = (
             target.split(":", 1)[1].strip()
             if target.startswith("selector:")
@@ -2610,8 +2644,17 @@ async def main():
 
             # Text-Eingabe — IMMER mit exaktem tabId
             elif next_action == "type_text":
-                params = {**next_params, **_tab_params()}
-                await execute_bridge("type_text", params)
+                ref = next_params.get("ref", "")
+                if ref:
+                    await execute_bridge("click_ref", {"ref": ref, **_tab_params()})
+                    await human_delay(0.4, 0.9)
+                    await execute_bridge(
+                        "type_text",
+                        {"text": next_params.get("text", ""), **_tab_params()},
+                    )
+                else:
+                    params = {**next_params, **_tab_params()}
+                    await execute_bridge("type_text", params)
 
             # Explizites Warten — nützlich bei Rate-Limits oder nach Auto-Submits
             elif next_action == "wait":

--- a/heypiggy_vision_worker.py
+++ b/heypiggy_vision_worker.py
@@ -49,8 +49,22 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+from agent_state_machine import (
+    AgentState,
+    IllegalTransitionError,
+    StepContext,
+    escalate,
+    fail_safe,
+    step_context_advance,
+)
 from predicate_checks import predicate_post_check, predicate_pre_check
-from vision_contract import NextAction, VisionResponse, VisionVerdict, parse_vision_response
+from sitepack_loader import SelectorNotFoundError, SitepackLoader
+from vision_contract import (
+    NextAction,
+    VisionResponse,
+    VisionVerdict,
+    parse_vision_response,
+)
 from vision_prompt import build_vision_prompt
 
 # ============================================================================
@@ -175,6 +189,19 @@ SESSION_DIR = ARTIFACT_DIR / "sessions"
 # Erstelle alle Verzeichnisse beim Start
 for d in [ARTIFACT_DIR, SCREENSHOT_DIR, AUDIT_DIR, SESSION_DIR]:
     d.mkdir(parents=True, exist_ok=True)
+
+
+# WHY: The sitepack loader externalizes every site-specific selector into a
+# versioned JSON manifest. This lets us adapt to HeyPiggy DOM drift without
+# rewriting worker logic.
+SITEPACK = SitepackLoader()
+SITEPACK_PATH = (
+    Path(__file__).resolve().parent / "sitepacks" / "heypiggy" / "v1" / "pack.json"
+)
+if SITEPACK_PATH.exists():
+    SITEPACK.load(str(SITEPACK_PATH))
+else:
+    print(f"[SITEPACK] Warnung: Sitepack nicht gefunden: {SITEPACK_PATH}")
 
 # ============================================================================
 # EXAKTE TAB-BINDUNG — GLOBAL STATE (PRIORITY -7.85)
@@ -759,16 +786,17 @@ async def resolve_survey_selector(selector: str, description: str = "") -> str:
         return selector
 
     lowered = selector.lower()
+    survey_list_selector = _sitepack_selector("survey_list_item", "div.survey-item")
     if "survey-item" not in lowered and "survey" not in lowered:
         return selector
 
     global CURRENT_TAB_ID, CURRENT_WINDOW_ID
     tab_params = _tab_params()
-    js_code = """
-    (function() {
-      const cards = Array.from(document.querySelectorAll('div.survey-item')).map((el) => {
+    js_code = f"""
+    (function() {{
+      const cards = Array.from(document.querySelectorAll({json.dumps(survey_list_selector)})).map((el) => {{
         const r = el.getBoundingClientRect();
-        return {
+        return {{
           id: el.id || '',
           text: (el.textContent || '').replace(/\\s+/g, ' ').trim(),
           visible: el.offsetParent !== null,
@@ -776,10 +804,10 @@ async def resolve_survey_selector(selector: str, description: str = "") -> str:
           y: Math.round(r.top + r.height / 2),
           w: Math.round(r.width),
           h: Math.round(r.height),
-        };
-      });
+        }};
+      }});
       return cards.filter((card) => card.visible && card.id);
-    })();
+    }})();
     """
     scan = await execute_bridge("execute_javascript", {"script": js_code, **tab_params})
     cards = []
@@ -1180,6 +1208,82 @@ def _page_type_to_page_state(page_type: str) -> str:
     return mapping.get((page_type or "unknown").strip().lower(), "unknown")
 
 
+def _safe_transition(
+    ctx: StepContext, new_state: AgentState, reason: str
+) -> StepContext:
+    """
+    Führt einen FSM-Übergang aus, ohne den Worker wegen eines doppelten oder
+    unerwarteten Status-Mappings hart zu stoppen.
+    WHY: Vision + DOM können denselben realen Zustand in mehreren Schleifen
+         hintereinander melden. Dann wäre ein erneuter Übergang illegal, aber
+         nicht fatal — wir loggen das sauber statt mitten im Run zu crashen.
+    CONSEQUENCES: Der Worker behält die harte FSM, aber bleibt robust gegen
+                  harmlose Wiederholungen im gleichen UI-Zustand.
+    """
+    try:
+        return step_context_advance(ctx, new_state, reason)
+    except IllegalTransitionError as exc:
+        audit("warning", message=f"FSM transition ignored: {exc}")
+        return ctx
+
+
+def _transition_for_page_state(
+    ctx: StepContext,
+    page_state: str,
+    verdict: str,
+) -> StepContext:
+    """
+    Übersetzt Worker-Page-States in FSM-Zustände.
+    WHY: Der Vision-Layer arbeitet mit UI-Zuständen wie `login`, `dashboard`
+         oder `survey_active`, während die Alpha-Orchestrierung harte AgentState-
+         Phasen braucht. Diese Brücke hält beide Welten synchron.
+    CONSEQUENCES: Checkpoints, Logs und spätere Resume-Logik sehen immer einen
+                  echten AgentState statt nur loser UI-Strings.
+    """
+    if page_state == "login":
+        return _safe_transition(ctx, AgentState.AUTHENTICATE, "Login page detected")
+    if page_state == "onboarding":
+        return _safe_transition(ctx, AgentState.ONBOARD, "Onboarding page detected")
+    if page_state == "dashboard":
+        return _safe_transition(ctx, AgentState.DISCOVER_WORK, "Dashboard detected")
+    if page_state == "survey":
+        return _safe_transition(
+            ctx, AgentState.SELECT_TASK, "Survey selection detected"
+        )
+    if page_state == "survey_active":
+        if ctx.state == AgentState.SELECT_TASK:
+            _safe_transition(
+                ctx, AgentState.ENTER_TASK, "Entering selected survey task"
+            )
+        return _safe_transition(
+            ctx, AgentState.EXECUTE_TASK_LOOP, "Survey question loop active"
+        )
+    if page_state == "survey_done":
+        _safe_transition(ctx, AgentState.VALIDATE_OUTCOME, "Survey completion detected")
+        return _safe_transition(
+            ctx, AgentState.RECORD_RESULT, "Recording survey result"
+        )
+    if verdict == VisionVerdict.STOP.value:
+        return ctx
+    return ctx
+
+
+def _sitepack_selector(name: str, fallback: str) -> str:
+    """
+    Holt einen Selektor aus dem Sitepack und fällt laut auf einen bekannten
+    Hard-Fallback zurück, wenn der Pack-Eintrag fehlt.
+    WHY: Die Integration muss jetzt schon robust laufen, auch wenn einzelne
+         Sitepack-Einträge noch nicht final live-verifiziert sind.
+    CONSEQUENCES: Wir profitieren sofort von zentralen Selektoren, ohne dass
+                  der Worker bei einem fehlenden Key komplett unbenutzbar wird.
+    """
+    if not SITEPACK.is_loaded:
+        return fallback
+    try:
+        return SITEPACK.get_selector(name)
+    except (SelectorNotFoundError, RuntimeError):
+        return fallback
+
 
 def _next_action_to_worker_command(next_action: NextAction) -> tuple[str, dict]:
     """
@@ -1215,7 +1319,11 @@ def _next_action_to_worker_command(next_action: NextAction) -> tuple[str, dict]:
         return "none", {}
 
     if action_type == "type":
-        selector = target.split(":", 1)[1].strip() if target.startswith("selector:") else target
+        selector = (
+            target.split(":", 1)[1].strip()
+            if target.startswith("selector:")
+            else target
+        )
         return "type_text", {"selector": selector, "text": value}
 
     if action_type == "scroll":
@@ -1230,7 +1338,6 @@ def _next_action_to_worker_command(next_action: NextAction) -> tuple[str, dict]:
     return "none", {}
 
 
-
 def _copy_vision_response(response: VisionResponse, update: dict) -> VisionResponse:
     """
     Erstellt ein aktualisiertes VisionResponse-Objekt kompatibel mit Pydantic v1/v2.
@@ -1240,7 +1347,6 @@ def _copy_vision_response(response: VisionResponse, update: dict) -> VisionRespo
     if hasattr(response, "model_copy"):
         return response.model_copy(update=update)
     return response.copy(update=update)
-
 
 
 def _apply_vision_response_policy(response: VisionResponse) -> VisionResponse:
@@ -1266,7 +1372,6 @@ def _apply_vision_response_policy(response: VisionResponse) -> VisionResponse:
         return _copy_vision_response(response, {"verdict": VisionVerdict.ESCALATE})
 
     return response
-
 
 
 def _vision_response_to_decision(response: VisionResponse) -> dict:
@@ -1626,7 +1731,10 @@ async def escalating_click(
     if not selector and description:
         desc_lower = description.lower()
         if "umfrage" in desc_lower or "survey" in desc_lower or "€" in desc_lower:
-            selector = await resolve_survey_selector("div.survey-item", description)
+            selector = await resolve_survey_selector(
+                _sitepack_selector("survey_list_item", "div.survey-item"),
+                description,
+            )
 
     methods = []
     if ref:
@@ -2106,7 +2214,6 @@ async def auto_resolve_blocker(
     return False
 
 
-
 def _selector_for_predicate(next_action: str, next_params: dict) -> str:
     """
     Extrahiert den CSS-Selektor für die DOM-Predicate-Prüfungen.
@@ -2187,6 +2294,14 @@ async def run_click_action(
 
 
 async def main():
+    ctx = StepContext(
+        state=AgentState.INIT,
+        step_index=0,
+        max_steps=MAX_STEPS,
+        task_url="https://www.heypiggy.com/login",
+    )
+    _safe_transition(ctx, AgentState.PREFLIGHT, "Initializing worker")
+
     audit(
         "start",
         message="A2A-SIN-Worker-HeyPiggy Vision Gate v2.0",
@@ -2199,11 +2314,15 @@ async def main():
         await wait_for_extension(timeout=600)
     except Exception as e:
         audit("stop", reason=f"Bridge-Verbindung fehlgeschlagen: {e}")
+        _safe_transition(
+            ctx, AgentState.FAIL_SAFE, f"Bridge-Verbindung fehlgeschlagen: {e}"
+        )
         return
 
     # 2. PRE-FLIGHT — Pflicht-Env + Vision-Auth müssen VOR Browser-Mutation healthy sein
     preflight = await ensure_worker_preflight()
     if not preflight.get("ok"):
+        _safe_transition(ctx, AgentState.FAIL_SAFE, "Preflight fehlgeschlagen")
         return
 
     # Credentials erst NACH erfolgreichem fail-closed Preflight auslesen.
@@ -2214,6 +2333,9 @@ async def main():
 
     # 3. VISION GATE CONTROLLER INITIALISIEREN
     gate = VisionGateController()
+    _safe_transition(
+        ctx, AgentState.ACQUIRE_SESSION, "Bridge healthy and gate initialized"
+    )
 
     # 4. INITIALE NAVIGATION
     action_desc = "Navigiere zu HeyPiggy Dashboard"
@@ -2246,11 +2368,17 @@ async def main():
             return
     except Exception as e:
         audit("stop", reason=f"Initiale Navigation fehlgeschlagen: {e}")
+        _safe_transition(
+            ctx, AgentState.FAIL_SAFE, f"Initiale Navigation fehlgeschlagen: {e}"
+        )
         return
 
     # Verifikation: CURRENT_TAB_ID muss jetzt gesetzt sein
     if CURRENT_TAB_ID is None:
         audit("stop", reason="CURRENT_TAB_ID ist nach Init immer noch None — Abbruch")
+        _safe_transition(
+            ctx, AgentState.FAIL_SAFE, "CURRENT_TAB_ID ist nach Init immer noch None"
+        )
         return
 
     # Warten auf Seitenlade
@@ -2261,15 +2389,32 @@ async def main():
 
     # 5. VISION GATE LOOP — Das Herzstück
     while gate.should_continue():
+        ctx.no_progress_counter = gate.no_progress_count
+        ctx.step_index = gate.total_steps
+        if gate.no_progress_count >= MAX_NO_PROGRESS:
+            _safe_transition(
+                ctx,
+                AgentState.FAIL_SAFE,
+                "Gate detected no-progress threshold exhaustion",
+            )
+            break
+        if gate.consecutive_retries >= MAX_RETRIES:
+            _safe_transition(ctx, AgentState.ESCALATE, "Gate detected retry exhaustion")
+            break
+
         # ---- Bridge-Health-Check vor JEDER Iteration ----
         if not await check_bridge_alive():
             audit("stop", reason="Bridge nicht erreichbar, Abbruch")
+            _safe_transition(
+                ctx, AgentState.FAIL_SAFE, "Bridge nicht erreichbar während Vision-Loop"
+            )
             break
 
         # ---- SCREENSHOT ----
         img_path, img_hash = await take_screenshot(
             gate.total_steps + 1, label=action_desc[:20]
         )
+        ctx.last_page_fingerprint = img_hash or ctx.last_page_fingerprint
         if not img_path:
             gate.record_step("RETRY", None)
             await human_delay(2.0, 4.0)
@@ -2280,6 +2425,9 @@ async def main():
         await human_delay(5.0, 10.0)
 
         # ---- VISION CHECK ----
+        _safe_transition(
+            ctx, AgentState.ASSESS_PAGE, "Assessing current page state via vision"
+        )
         decision = await ask_vision(
             img_path, action_desc, expected, gate.total_steps + 1
         )
@@ -2301,6 +2449,7 @@ async def main():
             verdict = VisionVerdict.ESCALATE.value
             reason = f"Non-resolvable blocker: {blocker.get('type')} — {blocker.get('detail', '')}"
 
+        _transition_for_page_state(ctx, page_state, verdict)
         gate.record_step(verdict, img_hash, page_state)
 
         print(f"\n{'=' * 60}")
@@ -2338,6 +2487,10 @@ async def main():
                 blocker=blocker,
             )
             await save_session("stop_state")
+            if verdict == VisionVerdict.ESCALATE.value:
+                _safe_transition(ctx, AgentState.ESCALATE, reason)
+                break
+            _safe_transition(ctx, AgentState.FAIL_SAFE, reason)
             break
 
         # ---- RETRY ----
@@ -2356,6 +2509,9 @@ async def main():
                 total_steps=gate.total_steps,
             )
             await save_session("completed")
+            _safe_transition(
+                ctx, AgentState.COMPLETE, "Vision reported task completion"
+            )
             break
 
         # ---- SURVEY DONE — Bestätigungsseite erkannt ----
@@ -2464,6 +2620,7 @@ async def main():
             # Navigation — IMMER mit exaktem tabId, KEIN Fallback ohne tabId
             elif next_action == "navigate":
                 url = next_params.get("url", "")
+                ctx.task_url = url or ctx.task_url
                 await execute_bridge("navigate", {"url": url, **_tab_params()})
                 await save_session(f"nav_{gate.total_steps}")
 

--- a/heypiggy_vision_worker.py
+++ b/heypiggy_vision_worker.py
@@ -334,11 +334,31 @@ def collect_opencode_text(stdout: bytes, stderr: bytes = b"") -> str:
             full_text += event.get("part", {}).get("text", "")
         elif event.get("type") == "error":
             error_data = event.get("error", {}) or {}
-            error_message = error_data.get("message", "")
-            provider_id = error_data.get("data", {}).get("providerID", "")
+            error_payload = error_data.get("data", {}) or {}
+            error_message = error_data.get("message", "") or error_payload.get(
+                "message", ""
+            )
+            provider_id = error_payload.get("providerID", "")
             if provider_id or error_message:
                 full_text += f" {provider_id} {error_message}".strip()
     return full_text.strip()
+
+
+def build_clean_opencode_env() -> dict:
+    """
+    Entfernt verschachtelte OpenCode-Session-Variablen aus der Child-Umgebung.
+    WHY: Der Worker ruft `opencode run` als untergeordneten Prozess auf. Wenn
+         dabei `OPENCODE=1`, `OPENCODE_PID` oder andere OpenCode-Laufzeitvariablen
+         vererbt werden, verhält sich der Child-Prozess wie eine verschachtelte
+         Session statt wie ein sauberer One-Shot-CLI-Call.
+    CONSEQUENCES: Vision-Aufrufe laufen isoliert und werden nicht vom aktuell
+                  laufenden Eltern-Agenten-Kontext kontaminiert.
+    """
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("OPENCODE")
+    }
 
 
 def detect_vision_auth_failure(raw_text: str) -> str | None:
@@ -421,10 +441,12 @@ async def run_vision_model(
             pass
 
     try:
+        child_env = build_clean_opencode_env()
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=child_env,
         )
         try:
             stdout, stderr = await asyncio.wait_for(

--- a/heypiggy_vision_worker.py
+++ b/heypiggy_vision_worker.py
@@ -49,6 +49,10 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+from predicate_checks import predicate_post_check, predicate_pre_check
+from vision_contract import NextAction, VisionResponse, VisionVerdict, parse_vision_response
+from vision_prompt import build_vision_prompt
+
 # ============================================================================
 # USER PROFIL — Jeremy Schulze
 # WHY: Der Worker muss Profil-Fragen (Region, Wohnort, Geschlecht, Name etc.)
@@ -1158,6 +1162,143 @@ async def dom_prescan():
     return "\n\n".join(filter(None, [page_context, snapshot_info, clickable_info]))
 
 
+def _page_type_to_page_state(page_type: str) -> str:
+    """
+    Übersetzt den neuen Vision-V2 `page_type` in die vorhandenen Worker-Zustände.
+    WHY: Der Rest des Workers arbeitet weiterhin mit den etablierten Zustandsnamen
+         (`page_state`), während der neue Vision-Vertrag bewusst kompakter ist.
+    CONSEQUENCES: Die Integration bleibt klein und rückwärtskompatibel.
+    """
+    mapping = {
+        "login": "login",
+        "survey_list": "dashboard",
+        "survey_question": "survey_active",
+        "survey_complete": "survey_done",
+        "captcha": "captcha",
+        "unknown": "unknown",
+    }
+    return mapping.get((page_type or "unknown").strip().lower(), "unknown")
+
+
+
+def _next_action_to_worker_command(next_action: NextAction) -> tuple[str, dict]:
+    """
+    Übersetzt die generische Vision-V2 Aktion in konkrete Worker-/Bridge-Befehle.
+    WHY: Der JSON-Vertrag soll modellseitig generisch bleiben, während der Worker
+         weiterhin seine bestehenden spezialisierten Klick- und Scrollpfade nutzt.
+    CONSEQUENCES: Alte Bridge-Methoden können weiterverwendet werden, ohne dass das
+                  Modell deren gesamte interne Namenswelt kennen muss.
+    """
+    action_type = (next_action.type or "none").strip().lower()
+    target = (next_action.target or "").strip()
+    value = (next_action.value or "").strip()
+
+    if action_type == "click":
+        if target.startswith("selector:"):
+            return "click_element", {"selector": target.split(":", 1)[1].strip()}
+        if target.startswith("ref:"):
+            return "click_ref", {"ref": target.split(":", 1)[1].strip()}
+        if target.startswith("text:"):
+            return "vision_click", {"description": target.split(":", 1)[1].strip()}
+        if target.startswith("coords:"):
+            coords = target.split(":", 1)[1].split(",", 1)
+            if len(coords) == 2:
+                try:
+                    return "click_coordinates", {
+                        "x": int(coords[0].strip()),
+                        "y": int(coords[1].strip()),
+                    }
+                except ValueError:
+                    pass
+        if target:
+            return "vision_click", {"description": target}
+        return "none", {}
+
+    if action_type == "type":
+        selector = target.split(":", 1)[1].strip() if target.startswith("selector:") else target
+        return "type_text", {"selector": selector, "text": value}
+
+    if action_type == "scroll":
+        direction = value.lower() if value else "down"
+        if direction in {"up", "scroll_up"}:
+            return "scroll_up", {}
+        return "scroll_down", {}
+
+    if action_type == "wait":
+        return "wait", {"reason": value or target or "vision_requested_wait"}
+
+    return "none", {}
+
+
+
+def _copy_vision_response(response: VisionResponse, update: dict) -> VisionResponse:
+    """
+    Erstellt ein aktualisiertes VisionResponse-Objekt kompatibel mit Pydantic v1/v2.
+    WHY: HF-VMs können je nach Image unterschiedliche Pydantic-Versionen haben.
+    CONSEQUENCES: Die Policy-Logik bleibt versionsstabil und testbar.
+    """
+    if hasattr(response, "model_copy"):
+        return response.model_copy(update=update)
+    return response.copy(update=update)
+
+
+
+def _apply_vision_response_policy(response: VisionResponse) -> VisionResponse:
+    """
+    Erzwingt fail-closed Worker-Regeln auf dem bereits geparsten Vision-Objekt.
+    WHY: Auch formal gültiges JSON darf die Schleife nicht blind fortsetzen, wenn
+         die Konfidenz zu niedrig ist oder ein nicht lösbarer Blocker vorliegt.
+    CONSEQUENCES: Niedrige Sicherheit wird deterministisch zu RETRY oder ESCALATE.
+    """
+    if response.confidence < 0.6:
+        return _copy_vision_response(
+            response,
+            {
+                "verdict": VisionVerdict.RETRY,
+                "reasoning": (
+                    f"Low-confidence vision response ({response.confidence:.2f}); retry required."
+                ),
+                "next_action": NextAction(type="none", target="", value=""),
+            },
+        )
+
+    if response.blocker and not response.blocker.auto_resolvable:
+        return _copy_vision_response(response, {"verdict": VisionVerdict.ESCALATE})
+
+    return response
+
+
+
+def _vision_response_to_decision(response: VisionResponse) -> dict:
+    """
+    Wandelt das strikte Vision-V2 Modell in das bestehende Worker-Decision-Dict um.
+    WHY: So kann der Hauptloop minimal angepasst werden, während Tests und Prompt
+         bereits vollständig auf dem neuen Vertrag laufen.
+    CONSEQUENCES: Alte Konsumenten lesen weiterhin `page_state`, `next_action` und
+                  `next_params`, bekommen diese Felder jetzt aber aus validiertem JSON.
+    """
+    next_action_name, next_params = _next_action_to_worker_command(response.next_action)
+    blocker = response.blocker
+    return {
+        "verdict": response.verdict.value,
+        "confidence": response.confidence,
+        "page_type": response.page_type,
+        "page_state": _page_type_to_page_state(response.page_type),
+        "reason": response.reasoning,
+        "progress": bool(response.dom_hash),
+        "next_action": next_action_name,
+        "next_params": next_params,
+        "dom_hash": response.dom_hash,
+        "blocker": {
+            "type": blocker.type,
+            "detail": blocker.detail,
+            "auto_resolvable": blocker.auto_resolvable,
+        }
+        if blocker
+        else None,
+    }
+
+
 # ============================================================================
 # VISION GATE — Gemini 3 Flash Analyse mit gehärtetem Prompt + DOM-Kontext
 # ============================================================================
@@ -1167,117 +1308,23 @@ async def ask_vision(
     screenshot_path: str, action_desc: str, expected: str, step_num: int
 ):
     """
-    Sendet einen Screenshot + DOM-Kontext an Gemini 3 Flash.
-    WHY: KEIN EINZIGER KLICK ohne dass das Vision-Modell den Bildschirm gesehen hat.
-    CONSEQUENCES: Bei Parse-Fehler wird RETRY zurückgegeben (nie ein Crash).
+    Sendet einen Screenshot + DOM-Kontext an das Vision-Modell und erzwingt den
+    Vision-Gate-V2 JSON-Vertrag.
+    WHY: Das Modell darf keine freien Texte mehr liefern, weil die Worker-Logik
+         auf einem strikt validierten Antwortschema aufbauen muss.
+    CONSEQUENCES: Jede Antwort wird über `parse_vision_response()` normalisiert;
+                  bei Parse- oder Policy-Fehlern fällt der Worker fail-closed auf
+                  RETRY oder STOP zurück.
     """
-    # DOM Pre-Scan: Echte Selektoren VOR dem Vision-Call holen!
+    # DOM-Kontext bleibt Pflicht, damit das Modell echte Selektoren und Ref-Hinweise
+    # sieht statt sich Klick-Ziele auszudenken.
     dom_context = await dom_prescan()
 
-    # Profil-Kontext aus gespeichertem User-Profil laden
-    # WHY: Gemini muss wissen wer der User ist um Profil-Fragen korrekt zu beantworten.
-    #      Ohne Profil würde Gemini zufällig wählen → falsche Region, falscher Name etc.
+    # Profil-Kontext bleibt zusätzlich erhalten, damit Profil- und Login-Fragen auf
+    # echten Nutzerdaten basieren statt auf Fantasie-Antworten.
     profile_context = _build_profile_context()
-
-    prompt = f"""Du bist der Vision Gate Controller der OpenSIN-Bridge.
-
-KONTEXT:
-- Letzte Aktion: '{action_desc}'
-- Erwartetes Ergebnis: '{expected}'
-- Schritt Nummer: {step_num} von maximal {MAX_STEPS}
-
-{profile_context}
-
-{dom_context}
-
-AUFGABE — Analysiere den Screenshot UND die DOM-Daten oben PRÄZISE:
-
-1. BLOCKIERUNGEN: Sind Captchas, Cookie-Banner, Consent-Modals, Login-Dialoge, Popups, Overlays oder Error-Messages sichtbar?
-   → Wenn ja: Diese ZUERST schliessen/akzeptieren!
-
-2. AKTUELLER STATUS: Was zeigt die Seite GENAU an?
-
-3. FORTSCHRITT: Hat sich gegenüber der letzten Aktion etwas verändert?
-
-4. NÄCHSTE AKTION: Was muss als nächstes passieren?
-
-VERFÜGBARE AKTIONEN (wähle GENAU EINE):
-- "click_element" — Standard CSS-Selektor Klick. Params: {{"selector": "#id-oder-.klasse"}}
-- "click_ref" — Klick per Accessibility-Tree-Ref (z.B. @e9). BEVORZUGT für Radio-Buttons, Checkboxen, Links ohne ID! Params: {{"ref": "@e9"}}
-- "ghost_click" — Voller Pointer+Mouse Event-Stack für SPA/React-Elemente. Params: {{"selector": "#echte-id"}}
-- "vision_click" — Beschreibungsbasierter Klick. Params: {{"description": "Text des Elements"}}
-- "click_coordinates" — Absoluter Pixel-Klick. Params: {{"x": 100, "y": 200}}
-- "keyboard" — Tastatur verwenden (z.B. Tab, Enter). Params: {{"keys": ["Enter"], "selector": "#optional-id"}}
-- "type_text" — Text eingeben. Params: {{"selector": "css", "text": "wert"}}
-- "navigate" — URL aufrufen. Params: {{"url": "https://..."}}
-- "scroll_down" — Seite nach unten scrollen
-- "scroll_up" — Seite nach oben scrollen
-- "none" — Aufgabe erledigt, nichts mehr zu tun
-
-ABSOLUTE PFLICHT-REGELN FÜR SELEKTOREN:
-- NUTZE NUR Selektoren aus der DOM-Analyse oben! NIEMALS raten!
-- Pseudo-Selektoren wie :has-text(), :contains(), :has() sind VERBOTEN (existieren nicht in CSS)!
-- Bevorzuge #id Selektoren (z.B. #survey-65076903) — die sind IMMER eindeutig!
-- WICHTIG: input[type='radio'][value='X'] NIEMALS nutzen — HeyPiggy Radio-Buttons haben KEINE value= Attribute!
-- Für Radio-Buttons → IMMER click_ref mit dem @eX Ref aus dem ACCESSIBILITY-TREE oben nutzen!
-- Für Survey-Karten auf HeyPiggy: Die Klasse ist .survey-item (NICHT .survey-card!), jede Karte hat eine eindeutige ID wie #survey-XXXXXXXX
-- Nutze ghost_click für alle div-basierten Karten (cursor: pointer)
-- Playwright-only Texte-Selektoren wie :contains(), :has-text() oder :text() sind VERBOTEN.
-- Wenn du Textreferenz brauchst, nenne den echten CSS-Selektor aus dem DOM-Pre-Scan oder eine eindeutige #id.
-- CONSENT-MODAL "Nächste" Button: IMMER #submit-button-cpx nutzen! NIEMALS button.modal-button-positive — das trifft dutzende versteckte Buttons im DOM und funktioniert nicht!
-
-KLICK-STRATEGIE:
-- Für Radio-Buttons ([radio @eX] im Accessibility-Tree) → click_ref mit {{"ref": "@eX"}} — das ist PFLICHT!
-- Für <button>, <a>, <input> → click_element
-- Für div.survey-item / div[cursor=pointer] → ghost_click mit #id-Selektor
-- Für Elemente ohne CSS-Selektor → vision_click mit Beschreibung
-- Letzter Ausweg → click_coordinates mit x,y aus der DOM-Analyse
-
-PAGE STATE REGELN — KRITISCH:
-- "dashboard" → HeyPiggy Startseite mit Survey-Liste, noch keine Umfrage gestartet
-- "login" → Login-Formular sichtbar
-- "onboarding" → Profil-Modal/Onboarding-Fragen (Region, Name, etc.) — VOR dem eigentlichen Dashboard!
-- "survey_active" → UMFRAGE LÄUFT GERADE! Fragen werden angezeigt (Radio-Buttons, Dropdowns, Textfelder, Skalen). NIEMALS "none" zurückgeben solange Fragen sichtbar sind!
-- "survey" → Survey-Auswahl / Übergangsseite (zwischen Dashboard und aktiver Umfrage)
-- "survey_done" → Umfrage erfolgreich abgeschlossen, Bestätigungsseite
-- "error" → Fehlermeldung, Timeout oder unbekannter Zustand
-- "unknown" → Seite nicht klar erkennbar
-
-PROFIL-FRAGEN REGELN — KRITISCH:
-- Wenn ein Modal mit Profil-Fragen sichtbar ist (Region, Wohnort, Geschlecht, Name, Alter etc.):
-  page_state="onboarding" setzen!
-- Nutze IMMER das BENUTZERPROFIL oben um die korrekte Antwort zu wählen!
-- Region-Frage ("In welcher Region wohnst du?"): IMMER "Norden" wählen (Jeremy wohnt in Berlin, wählt Norden)
-- Nach Auswahl der Antwort → "Nächste"/"Weiter" Button klicken!
-- Profil-Modals MÜSSEN vollständig ausgefüllt werden bevor Umfragen gestartet werden!
-
-UMFRAGE-REGELN — ÄUSSERST WICHTIG:
-- Wenn page_state="survey_active": BEENDE DIE UMFRAGE VOLLSTÄNDIG! Klicke ALLE Fragen durch bis zur Bestätigungsseite!
-- Wenn eine Frage sichtbar ist → IMMER beantworten und "Weiter"/"Next"/"Submit" klicken!
-- NIEMALS next_action="none" wenn noch Fragen offen sind!
-- Radio-Button Fragen → click_ref mit dem @eX Ref aus dem Accessibility-Tree (NICHT click_element mit value=!)
-- Dropdown-Fragen → click_element auf die gewünschte Option
-- Freitext-Fragen → type_text mit einer sinnvollen Antwort
-- Skalen-Fragen (1-5, 1-7, etc.) → click_element auf mittlere oder positive Option
-- "Weiter"/"Next"/"Fortfahren"/"Continue"/"Submit" Buttons → IMMER klicken nach einer Antwort!
-- Fortschrittsbalken sichtbar? → Umfrage läuft noch, page_state="survey_active"!
-
-REGELN:
-- Antworte AUSSCHLIESSLICH mit gültigem JSON! Kein Markdown, kein Text!
-- Bei Captchas oder unlösbaren Blockierungen: verdict="STOP"
-- Bei unveränderter Seite: verdict="RETRY" und schlage eine ANDERE Methode vor!
-- Credentials NIEMALS ausgeben! Nutze "<EMAIL>" und "<PASSWORD>" als Platzhalter.
-- Wähle IMMER die lukrativste verfügbare Umfrage (höchster €-Betrag)!
-
-ANTWORT-FORMAT (NUR dieses JSON, NICHTS anderes):
-{{
-  "verdict": "PROCEED",
-  "page_state": "dashboard|login|onboarding|survey|survey_active|survey_done|error|unknown",
-  "reason": "Kurze Analyse...",
-  "progress": true,
-  "next_action": "click_ref",
-  "next_params": {{"ref": "@e9"}}
-}}"""
+    prompt_dom_snapshot = "\n\n".join(filter(None, [profile_context, dom_context]))
+    prompt = build_vision_prompt(action_desc, expected, prompt_dom_snapshot)
 
     run_result = await run_vision_model(
         prompt,
@@ -1290,68 +1337,69 @@ ANTWORT-FORMAT (NUR dieses JSON, NICHTS anderes):
         error_reason = run_result.get("error", "Vision call failed")
         if run_result.get("auth_failure"):
             return {
-                "verdict": "STOP",
+                "verdict": VisionVerdict.STOP.value,
+                "confidence": 0.0,
                 "reason": f"Vision auth failed: {error_reason}",
                 "next_action": "none",
+                "next_params": {},
                 "page_state": "error",
+                "page_type": "unknown",
                 "progress": False,
+                "dom_hash": "",
+                "blocker": {
+                    "type": "auth",
+                    "detail": error_reason,
+                    "auto_resolvable": False,
+                },
             }
         return {
-            "verdict": "RETRY",
+            "verdict": VisionVerdict.RETRY.value,
+            "confidence": 0.0,
             "reason": error_reason,
             "next_action": "none",
+            "next_params": {},
             "page_state": "unknown",
+            "page_type": "unknown",
             "progress": False,
+            "dom_hash": "",
+            "blocker": None,
         }
 
     full_text = run_result.get("text", "")
 
     try:
-        # Markdown-Block entfernen falls vorhanden
-        if "```json" in full_text:
-            full_text = full_text.split("```json")[1].split("```")[0].strip()
-        elif "```" in full_text:
-            parts = full_text.split("```")
-            if len(parts) >= 3:
-                full_text = parts[1].strip()
-                # Falls der erste Teil nach ``` mit "json" beginnt, entfernen
-                if full_text.startswith("json"):
-                    full_text = full_text[4:].strip()
-
-        result = json.loads(full_text)
+        response = parse_vision_response(full_text)
+        response = _apply_vision_response_policy(response)
+        decision = _vision_response_to_decision(response)
         audit(
             "vision_check",
             step=step_num,
-            verdict=result.get("verdict"),
-            page_state=result.get("page_state"),
-            reason=result.get("reason", "")[:150],
-            next_action=result.get("next_action"),
+            verdict=decision.get("verdict"),
+            confidence=decision.get("confidence"),
+            page_state=decision.get("page_state"),
+            reason=decision.get("reason", "")[:150],
+            next_action=decision.get("next_action"),
         )
-        return result
+        return decision
 
-    except json.JSONDecodeError as e:
+    except Exception as e:
         audit(
             "error",
-            message=f"Vision JSON Parse Error: {e}",
+            message=f"Vision contract parse error: {e}",
             step=step_num,
             raw_output=full_text[:500],
         )
         return {
-            "verdict": "RETRY",
-            "reason": f"JSON Parse Error: {e}",
+            "verdict": VisionVerdict.RETRY.value,
+            "confidence": 0.0,
+            "reason": f"Vision contract parse error: {e}",
             "next_action": "none",
+            "next_params": {},
             "page_state": "unknown",
+            "page_type": "unknown",
             "progress": False,
-        }
-
-    except Exception as e:
-        audit("error", message=f"Vision Exception: {e}", step=step_num)
-        return {
-            "verdict": "RETRY",
-            "reason": str(e),
-            "next_action": "none",
-            "page_state": "unknown",
-            "progress": False,
+            "dom_hash": "",
+            "blocker": None,
         }
 
 
@@ -2020,6 +2068,61 @@ def inject_credentials(params: dict, email: str, pwd: str) -> dict:
     return params
 
 
+async def auto_resolve_blocker(
+    blocker: dict | None, next_action: str, next_params: dict, step_num: int
+) -> bool:
+    """
+    Versucht bekannte, explizit als automatisch lösbar markierte Blocker aufzulösen.
+    WHY: Vision Gate V2 liefert jetzt strukturierte Blocker-Daten statt nur Text.
+         Dadurch kann der Worker bei Modals oder Rate-Limits gezielt reagieren.
+    CONSEQUENCES: Gibt nur dann `True` zurück, wenn wirklich eine Auto-Resolution
+                  ausgeführt wurde; nicht lösbare Fälle eskalieren später hart.
+    """
+    if not blocker or not blocker.get("auto_resolvable"):
+        return False
+
+    blocker_type = (blocker.get("type") or "").strip().lower()
+    blocker_detail = blocker.get("detail", "")
+    audit(
+        "state_change",
+        message=f"Auto-resolvable blocker erkannt: {blocker_type} — {blocker_detail[:120]}",
+        step=step_num,
+    )
+
+    # Wenn das Vision-Modell bereits eine konkrete Folgeaktion vorgeschlagen hat,
+    # übernimmt der Hauptloop die tatsächliche Ausführung. Hier melden wir nur,
+    # dass dieser Blocker prinzipiell automatisch behandelbar ist.
+    if next_action != "none":
+        return False
+
+    if blocker_type == "modal":
+        await keyboard_action(["Escape"])
+        return True
+
+    if blocker_type == "rate_limit":
+        await human_delay(4.0, 7.0)
+        return True
+
+    return False
+
+
+
+def _selector_for_predicate(next_action: str, next_params: dict) -> str:
+    """
+    Extrahiert den CSS-Selektor für die DOM-Predicate-Prüfungen.
+    WHY: Nur CSS-Selektoren können zuverlässig auf Sichtbarkeit/Klickbarkeit und
+         Okklusion geprüft werden; Ref- oder Koordinaten-Klicks haben keinen DOM-
+         Selektor, werden aber trotzdem mit einem DOM-Hash-Snapshot versehen.
+    CONSEQUENCES: Selektorlose Aktionen liefern einen leeren String und werden von
+                  den Predicate-Checks als `skipped` behandelt.
+    """
+    if next_action == "type_text":
+        return normalize_selector(next_params.get("selector", ""))
+    if next_action == "click_element":
+        return normalize_selector(next_params.get("selector", ""))
+    return ""
+
+
 # ============================================================================
 # SCROLL-HANDLER
 # ============================================================================
@@ -2181,14 +2284,23 @@ async def main():
             img_path, action_desc, expected, gate.total_steps + 1
         )
 
-        verdict = decision.get("verdict", "RETRY")
+        verdict = decision.get("verdict", VisionVerdict.RETRY.value)
         reason = decision.get("reason", "Kein Grund")
         page_state = decision.get("page_state", "unknown")
+        page_type = decision.get("page_type", "unknown")
         next_action = decision.get("next_action", "none")
         next_params = decision.get("next_params", {})
         progress = decision.get("progress", False)
+        blocker = decision.get("blocker")
+        confidence = float(decision.get("confidence", 0.0) or 0.0)
 
         # Schritt aufzeichnen
+        # WHY: Blocker-Eskalationen müssen VOR dem Gate-Tracking angewendet werden,
+        # damit der Retry-/Stop-Zähler den finalen, nicht den vorläufigen Zustand sieht.
+        if blocker and not blocker.get("auto_resolvable"):
+            verdict = VisionVerdict.ESCALATE.value
+            reason = f"Non-resolvable blocker: {blocker.get('type')} — {blocker.get('detail', '')}"
+
         gate.record_step(verdict, img_hash, page_state)
 
         print(f"\n{'=' * 60}")
@@ -2204,14 +2316,32 @@ async def main():
         )
         print(f"{'=' * 60}\n")
 
-        # ---- STOP ----
-        if verdict == "STOP":
-            audit("stop", reason=reason, page_state=page_state)
+        # ---- BLOCKER POLICY ----
+        # WHY: Vision Gate V2 liefert Blocker als strukturierte Daten. Dadurch kann
+        # der Worker automatische Fälle behandeln und harte Fälle explizit eskalieren.
+        if blocker and blocker.get("auto_resolvable"):
+            resolved_inline = await auto_resolve_blocker(
+                blocker, next_action, next_params, gate.total_steps
+            )
+            if resolved_inline:
+                await human_delay(1.0, 2.0)
+                continue
+
+        # ---- STOP / ESCALATE ----
+        if verdict in {VisionVerdict.STOP.value, VisionVerdict.ESCALATE.value}:
+            audit(
+                "stop",
+                reason=reason,
+                page_state=page_state,
+                page_type=page_type,
+                confidence=confidence,
+                blocker=blocker,
+            )
             await save_session("stop_state")
             break
 
         # ---- RETRY ----
-        if verdict == "RETRY":
+        if verdict == VisionVerdict.RETRY.value:
             # Bei RETRY den Selektor als fehlgeschlagen merken
             if next_params.get("selector"):
                 gate.add_failed_selector(next_params["selector"])
@@ -2278,6 +2408,33 @@ async def main():
         except Exception:
             pass
 
+        predicate_before_hash = ""
+        predicate_selector = _selector_for_predicate(next_action, next_params)
+        if next_action in CLICK_ACTIONS or next_action == "type_text":
+            try:
+                predicate_pre = await asyncio.to_thread(
+                    predicate_pre_check, BRIDGE_MCP_URL, predicate_selector
+                )
+                predicate_before_hash = predicate_pre.get("dom_hash", "")
+                audit(
+                    "predicate_pre",
+                    step=gate.total_steps,
+                    action=next_action,
+                    selector=predicate_selector,
+                    ok=predicate_pre.get("ok"),
+                    skipped=predicate_pre.get("skipped"),
+                    visible=predicate_pre.get("visible"),
+                    clickable=predicate_pre.get("clickable"),
+                    not_occluded=predicate_pre.get("not_occluded"),
+                    reason=predicate_pre.get("reason"),
+                )
+                if predicate_selector and not predicate_pre.get("ok"):
+                    gate.add_failed_selector(predicate_selector)
+                    await human_delay(1.0, 2.0)
+                    continue
+            except Exception as e:
+                audit("error", message=f"Predicate pre-check failed: {e}")
+
         try:
             # Scroll-Aktionen
             if next_action in ("scroll_down", "scroll_up"):
@@ -2299,6 +2456,10 @@ async def main():
             elif next_action == "type_text":
                 params = {**next_params, **_tab_params()}
                 await execute_bridge("type_text", params)
+
+            # Explizites Warten — nützlich bei Rate-Limits oder nach Auto-Submits
+            elif next_action == "wait":
+                await human_delay(2.0, 5.0)
 
             # Navigation — IMMER mit exaktem tabId, KEIN Fallback ohne tabId
             elif next_action == "navigate":
@@ -2324,8 +2485,29 @@ async def main():
         # DOM-Verifikation prüft URL + Title — ändert sich irgendeins, war es echter Fortschritt.
         # KONSEQUENZ: mark_dom_progress() setzt no_progress_count zurück → kein vorzeitiger Abbruch.
         await asyncio.sleep(1.0)
+
+        predicate_post = None
+        if next_action in CLICK_ACTIONS or next_action == "type_text":
+            try:
+                predicate_post = await asyncio.to_thread(
+                    predicate_post_check, BRIDGE_MCP_URL, predicate_before_hash
+                )
+                audit(
+                    "predicate_post",
+                    step=gate.total_steps,
+                    action=next_action,
+                    selector=predicate_selector,
+                    changed=predicate_post.get("changed"),
+                    new_hash=predicate_post.get("new_hash", "")[:16],
+                )
+            except Exception as e:
+                audit("error", message=f"Predicate post-check failed: {e}")
+
         dom_check = await dom_verify_change(before_url, before_title)
-        if dom_check.get("changed"):
+        dom_changed = dom_check.get("changed") or bool(
+            predicate_post and predicate_post.get("changed")
+        )
+        if dom_changed:
             # DOM hat sich verändert → echter Fortschritt → no_progress_count zurücksetzen
             gate.mark_dom_progress()
             audit(

--- a/predicate_checks.py
+++ b/predicate_checks.py
@@ -1,0 +1,190 @@
+"""DOM predicate checks used before and after browser mutations.
+
+WHY:
+- Vision alone is not enough to prove that an element is interactable.
+- The worker needs a deterministic DOM-side safety check before click/type and a
+  deterministic DOM hash comparison afterwards.
+
+CONSEQUENCES:
+- Pre-action checks can fail closed when a selector is invisible or occluded.
+- Post-action checks can report real DOM progress even when screenshots look
+  visually similar between survey steps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.request
+from typing import Any
+
+
+def _sha256_text(value: str) -> str:
+    """Returns the SHA-256 hash of normalized body text."""
+
+    return hashlib.sha256((value or "").encode("utf-8")).hexdigest()
+
+
+def _bridge_tool_call(bridge_url: str, tool_name: str, arguments: dict[str, Any]) -> Any:
+    """Executes one JSON-RPC bridge tool call over HTTP.
+
+    WHY:
+    - The worker already talks to the bridge over JSON-RPC.
+    - Keeping a tiny local client here avoids importing the full worker module
+      and prevents circular dependencies between helper files.
+    """
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": arguments},
+    }
+    request = urllib.request.Request(
+        bridge_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        body = json.loads(response.read().decode("utf-8"))
+    if "error" in body:
+        raise RuntimeError(str(body["error"]))
+    result = body.get("result", {})
+
+    # Many bridge tools return a content array with a JSON blob wrapped as text.
+    # This decoder keeps the helper robust across the bridge response variants we
+    # already use in the worker.
+    if isinstance(result, dict) and isinstance(result.get("content"), list):
+        for entry in result["content"]:
+            if isinstance(entry, dict) and isinstance(entry.get("text"), str):
+                text = entry["text"].strip()
+                if not text:
+                    continue
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+    return result
+
+
+def predicate_pre_check(bridge_url, selector) -> dict:
+    """Checks whether a target selector is visible, clickable, and unobscured.
+
+    WHY:
+    - Browser automation must not guess that a selector is ready to receive a
+      click or text input.
+    - The worker also needs the current DOM hash before the mutation so the
+      subsequent post-check can prove whether the page changed.
+
+    CONSEQUENCES:
+    - Missing selectors fail closed with `ok=False`.
+    - Selector-less actions return a skipped result but still include the current
+      DOM hash so the caller can continue with a post-check.
+    """
+
+    selector_literal = json.dumps(selector or "")
+    script = f"""
+    (function() {{
+        var selector = {selector_literal};
+        var bodyText = (document.body && document.body.innerText) || '';
+        if (!selector) {{
+            return {{
+                ok: false,
+                skipped: true,
+                reason: 'missing_selector',
+                visible: false,
+                clickable: false,
+                not_occluded: false,
+                dom_text: bodyText
+            }};
+        }}
+        var el = document.querySelector(selector);
+        if (!el) {{
+            return {{
+                ok: false,
+                skipped: false,
+                reason: 'selector_not_found',
+                visible: false,
+                clickable: false,
+                not_occluded: false,
+                dom_text: bodyText
+            }};
+        }}
+
+        var rect = el.getBoundingClientRect();
+        var style = window.getComputedStyle(el);
+        var visible = !!(
+            rect.width > 0 &&
+            rect.height > 0 &&
+            style.display !== 'none' &&
+            style.visibility !== 'hidden' &&
+            style.opacity !== '0'
+        );
+        var disabled = !!(el.disabled || el.getAttribute('aria-disabled') === 'true');
+        var clickable = visible && !disabled && style.pointerEvents !== 'none';
+        var centerX = Math.max(0, Math.floor(rect.left + rect.width / 2));
+        var centerY = Math.max(0, Math.floor(rect.top + rect.height / 2));
+        var topEl = document.elementFromPoint(centerX, centerY);
+        var notOccluded = !!topEl && (topEl === el || el.contains(topEl) || topEl.contains(el));
+
+        return {{
+            ok: visible && clickable && notOccluded,
+            skipped: false,
+            reason: visible && clickable && notOccluded ? 'ok' : 'predicate_failed',
+            visible: visible,
+            clickable: clickable,
+            not_occluded: notOccluded,
+            dom_text: bodyText,
+            tag_name: el.tagName,
+            element_id: el.id || '',
+            class_name: (el.className || '').toString().slice(0, 120)
+        }};
+    }})();
+    """
+
+    result = _bridge_tool_call(
+        bridge_url,
+        "execute_javascript",
+        {"script": script},
+    )
+
+    if isinstance(result, dict) and "result" in result and isinstance(result["result"], dict):
+        result = result["result"]
+
+    if not isinstance(result, dict):
+        result = {
+            "ok": False,
+            "skipped": False,
+            "reason": "unexpected_bridge_result",
+            "visible": False,
+            "clickable": False,
+            "not_occluded": False,
+            "dom_text": "",
+        }
+
+    dom_text = str(result.pop("dom_text", "") or "")
+    result["dom_hash"] = _sha256_text(dom_text)
+    return result
+
+
+def predicate_post_check(bridge_url, before_hash: str) -> dict:
+    """Calculates the post-action DOM hash and reports whether it changed.
+
+    WHY:
+    - Survey pages often keep the same layout across many question steps.
+    - Comparing the body text hash is a cheap, deterministic signal for whether
+      the action produced actual page-level progress.
+    """
+
+    script = "(function() { return { dom_text: (document.body && document.body.innerText) || '' }; })();"
+    result = _bridge_tool_call(bridge_url, "execute_javascript", {"script": script})
+    if isinstance(result, dict) and "result" in result and isinstance(result["result"], dict):
+        result = result["result"]
+
+    dom_text = ""
+    if isinstance(result, dict):
+        dom_text = str(result.get("dom_text", "") or "")
+
+    new_hash = _sha256_text(dom_text)
+    return {"changed": bool(before_hash and before_hash != new_hash), "new_hash": new_hash}

--- a/sitepack_loader.py
+++ b/sitepack_loader.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Sitepack loader and validator for site-specific selector management.
+
+WHY THIS MODULE EXISTS:
+- Hardcoded CSS selectors in the worker break every time the target site
+  changes its DOM structure (class names, IDs, element hierarchy).
+- A sitepack externalizes ALL selectors into a versioned JSON manifest so the
+  worker itself never needs editing when a site updates its layout.
+- The worker becomes site-agnostic: swap the sitepack, target a different site.
+
+WHAT THIS MODULE PROVIDES:
+- SitepackLoader: loads, validates, and exposes selectors/flows/signatures
+- SitepackValidationError: raised when a sitepack JSON fails schema validation
+- SelectorNotFoundError: raised when a requested selector name doesn't exist
+
+CONSEQUENCES:
+- Zero hardcoded CSS selectors in the worker code
+- Selectors can be updated by non-developers (just edit the JSON)
+- Schema validation at load time catches errors before the worker starts clicking
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# WHY: jsonschema gives us robust validation against the sitepack schema.
+# If not installed, we fall back to manual required-key checks.
+try:
+    import jsonschema
+
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+
+class SitepackValidationError(Exception):
+    """Raised when a sitepack JSON file fails schema validation.
+
+    WHY: A domain-specific exception makes schema violations obvious and
+    distinguishable from generic JSON parse errors or file-not-found errors.
+    """
+
+    pass
+
+
+class SelectorNotFoundError(KeyError):
+    """Raised when a requested selector name does not exist in the loaded sitepack.
+
+    WHY: A domain-specific exception makes missing-selector bugs obvious.
+    The error message includes the list of available selectors so the caller
+    can quickly see what names are valid.
+    """
+
+    pass
+
+
+class SitepackLoader:
+    """Loads, validates, and exposes a versioned sitepack JSON manifest.
+
+    WHY THIS CLASS EXISTS:
+    - The worker needs a single, consistent interface to look up any CSS selector,
+      flow sequence, or page signature by name — without hardcoding strings.
+    - Centralizing lookups here means typos and missing selectors fail loudly
+      at the point of use, not silently deep in a click handler.
+
+    USAGE:
+        loader = SitepackLoader()
+        loader.load("sitepacks/heypiggy/v1/pack.json")
+        email_sel = loader.get_selector("login_email")  # "input[type='email']"
+
+    CONSEQUENCES:
+    - All selector references go through get_selector() — grep-able, auditable.
+    - Schema validation at load() catches structural errors immediately.
+    - match_page_type() enables deterministic page identification from DOM state.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty loader. Call load() before using any getters.
+
+        WHY: Separating init from load allows the worker to create the loader
+        at module level and defer loading until the sitepack path is known.
+        """
+        # WHY: _data holds the raw parsed JSON dict after load()
+        self._data: Dict[str, Any] = {}
+        # WHY: _loaded prevents accidental use before load() is called
+        self._loaded: bool = False
+        # WHY: _path stored for diagnostics and logging
+        self._path: str = ""
+
+    def load(self, path: str) -> None:
+        """Load and validate a sitepack JSON file from disk.
+
+        WHY: Validation at load time catches schema errors before the worker
+        starts clicking on missing or malformed selectors.
+
+        CONSEQUENCES:
+        - Raises FileNotFoundError if path doesn't exist
+        - Raises SitepackValidationError if schema validation fails
+        - On success, all getters become usable
+        """
+        # WHY: resolve() gives us an absolute path for clear error messages
+        resolved = Path(path).resolve()
+        if not resolved.exists():
+            raise FileNotFoundError(f"Sitepack not found: {resolved}")
+
+        # WHY: explicit encoding prevents platform-dependent surprises
+        with open(resolved, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        # WHY: The schema lives at sitepacks/schema.json — three levels up from
+        # sitepacks/heypiggy/v1/pack.json. We look for it relative to the pack.
+        schema_path = resolved.parent.parent.parent / "schema.json"
+
+        if HAS_JSONSCHEMA and schema_path.exists():
+            # WHY: jsonschema gives us detailed, human-readable validation errors
+            with open(schema_path, "r", encoding="utf-8") as sf:
+                schema = json.load(sf)
+            try:
+                jsonschema.validate(instance=data, schema=schema)
+            except jsonschema.ValidationError as e:
+                raise SitepackValidationError(
+                    f"Sitepack validation failed: {e.message}"
+                ) from e
+        else:
+            # WHY: Manual fallback ensures validation even without jsonschema installed.
+            # We check for the 5 required top-level keys that every sitepack must have.
+            for required_key in (
+                "site",
+                "version",
+                "selectors",
+                "flows",
+                "page_signatures",
+            ):
+                if required_key not in data:
+                    raise SitepackValidationError(
+                        f"Sitepack missing required key: '{required_key}'"
+                    )
+
+        # WHY: Only set _loaded=True after all validation passes —
+        # ensures the loader is never in a half-loaded broken state.
+        self._data = data
+        self._loaded = True
+        self._path = str(resolved)
+
+        # WHY: Startup log helps operators verify the right sitepack was loaded
+        print(f"[SITEPACK] Loaded {data['site']} v{data['version']} from {resolved}")
+
+    def get_selector(self, name: str) -> str:
+        """Return the CSS selector string for the given logical name.
+
+        WHY: Central lookup prevents typos, makes missing selectors obvious,
+        and provides a clear audit trail of which selectors the worker uses.
+
+        CONSEQUENCES:
+        - Raises RuntimeError if load() hasn't been called yet
+        - Raises SelectorNotFoundError if the name doesn't exist in the sitepack
+        """
+        if not self._loaded:
+            raise RuntimeError("Sitepack not loaded. Call load() first.")
+
+        selectors = self._data.get("selectors", {})
+        if name not in selectors:
+            raise SelectorNotFoundError(
+                f"Selector '{name}' not found in sitepack. "
+                f"Available: {sorted(selectors.keys())}"
+            )
+        return selectors[name]
+
+    def get_flow(self, name: str) -> List[str]:
+        """Return the ordered list of step names for the given flow.
+
+        WHY: Flows define the high-level sequence of actions for a task
+        (e.g., login flow = navigate → fill email → fill password → submit).
+        Externalizing them lets operators adjust sequences without code changes.
+        """
+        if not self._loaded:
+            raise RuntimeError("Sitepack not loaded. Call load() first.")
+
+        flows = self._data.get("flows", {})
+        if name not in flows:
+            raise KeyError(
+                f"Flow '{name}' not found. Available: {sorted(flows.keys())}"
+            )
+        return flows[name]
+
+    def get_page_signature(self, name: str) -> List[str]:
+        """Return the list of CSS selectors that identify a page type.
+
+        WHY: Page signatures let the worker deterministically identify which
+        page it's on by checking which selectors exist in the DOM — more
+        reliable than free-form vision text for known page types.
+        """
+        if not self._loaded:
+            raise RuntimeError("Sitepack not loaded. Call load() first.")
+
+        sigs = self._data.get("page_signatures", {})
+        if name not in sigs:
+            raise KeyError(
+                f"Page signature '{name}' not found. Available: {sorted(sigs.keys())}"
+            )
+        return sigs[name]
+
+    def match_page_type(self, visible_selectors: List[str]) -> str:
+        """Match visible selectors against page signatures to determine page type.
+
+        WHY: Instead of relying solely on vision model text to identify the
+        current page, the worker can check which signature selectors are
+        actually present in the DOM for a deterministic page classification.
+
+        ALGORITHM:
+        - For each page type, count how many of its signature selectors appear
+          in the visible_selectors list
+        - Return the page type with the highest overlap
+        - Return 'unknown' if no signatures match at all
+
+        CONSEQUENCES:
+        - Deterministic: same DOM state always produces the same classification
+        - Fast: pure set intersection, no LLM call needed
+        - Composable: can be combined with vision verdict for higher confidence
+        """
+        if not self._loaded:
+            raise RuntimeError("Sitepack not loaded. Call load() first.")
+
+        best_match = "unknown"
+        best_score = 0
+        # WHY: Converting to set for O(1) intersection lookups
+        visible_set = set(visible_selectors)
+
+        for page_type, signature_selectors in self._data.get(
+            "page_signatures", {}
+        ).items():
+            # WHY: Count how many signature selectors are present in the DOM
+            score = len(visible_set.intersection(set(signature_selectors)))
+            if score > best_score:
+                best_score = score
+                best_match = page_type
+
+        return best_match
+
+    @property
+    def site(self) -> str:
+        """The domain name of the loaded sitepack (e.g. 'heypiggy.com')."""
+        return self._data.get("site", "unknown")
+
+    @property
+    def version(self) -> str:
+        """The semver version string of the loaded sitepack."""
+        return self._data.get("version", "0.0.0")
+
+    @property
+    def is_loaded(self) -> bool:
+        """Whether a sitepack has been successfully loaded and validated."""
+        return self._loaded

--- a/sitepacks/heypiggy/v1/README.md
+++ b/sitepacks/heypiggy/v1/README.md
@@ -1,0 +1,37 @@
+# HeyPiggy Sitepack v1.0.0
+
+Site-specific selector pack for `heypiggy.com` browser automation.
+
+## Selector Inventory
+
+| Name | Selector | Status | Purpose |
+|------|----------|--------|---------|
+| `login_email` | `input[type='email']` | pending-verification | Email input on login page |
+| `login_password` | `input[type='password']` | pending-verification | Password input on login page |
+| `login_submit` | `button[type='submit']` | pending-verification | Submit button on login form |
+| `consent_next` | `#submit-button-cpx` | **verified** (DevTools 2026-04-11) | Consent modal "Nächste" button |
+| `survey_list_item` | `.survey-card` | pending-verification | Individual survey card on dashboard |
+| `survey_start` | `button.start-survey` | pending-verification | "Start Survey" button |
+| `survey_next` | `button.next-question, button[data-action='next']` | pending-verification | Next question button (multi-selector fallback) |
+| `survey_submit` | `button.submit-survey, button[type='submit'].final` | pending-verification | Final survey submit button |
+| `completion_indicator` | `.survey-complete, .thank-you, .completion-message` | pending-verification | Completion confirmation elements |
+
+## Verification Protocol
+
+Each selector must be verified using Chrome DevTools before moving to `verified` status:
+
+1. Open heypiggy.com in Chrome DevTools → Elements tab
+2. Run: `document.querySelector('<selector>')` in Console → must NOT return `null`
+3. Run: `element.offsetParent !== null` → must be `true` (visible)
+4. Screenshot the DevTools proof and link it here
+
+## Flows
+
+- **login**: Navigate → fill email → fill password → click submit
+- **onboard**: Click consent "Nächste" button
+- **survey_execute**: Click start → answer loop → click submit
+
+## Page Signatures
+
+Used by `SitepackLoader.match_page_type()` to deterministically identify the current page
+by checking which signature selectors are present in the DOM.

--- a/sitepacks/heypiggy/v1/pack.json
+++ b/sitepacks/heypiggy/v1/pack.json
@@ -1,0 +1,25 @@
+{
+  "site": "heypiggy.com",
+  "version": "1.0.0",
+  "selectors": {
+    "login_email": "input[type='email']",
+    "login_password": "input[type='password']",
+    "login_submit": "button[type='submit']",
+    "consent_next": "#submit-button-cpx",
+    "survey_list_item": ".survey-card",
+    "survey_start": "button.start-survey",
+    "survey_next": "button.next-question, button[data-action='next']",
+    "survey_submit": "button.submit-survey, button[type='submit'].final",
+    "completion_indicator": ".survey-complete, .thank-you, .completion-message"
+  },
+  "flows": {
+    "login": ["navigate_to_login", "fill_email", "fill_password", "click_submit"],
+    "onboard": ["click_consent_next"],
+    "survey_execute": ["click_start", "answer_loop", "click_submit"]
+  },
+  "page_signatures": {
+    "login": ["input[type='email']", "input[type='password']"],
+    "survey_list": [".survey-card", ".dashboard"],
+    "survey_complete": [".thank-you", ".completion", ".survey-complete"]
+  }
+}

--- a/sitepacks/schema.json
+++ b/sitepacks/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SIN Sitepack Schema",
+  "description": "Validates versioned site-specific selector packs for browser automation workers.",
+  "type": "object",
+  "required": ["site", "version", "selectors", "flows", "page_signatures"],
+  "additionalProperties": false,
+  "properties": {
+    "site": {
+      "type": "string",
+      "description": "Domain of the target site (e.g. heypiggy.com)"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semver version of this sitepack"
+    },
+    "selectors": {
+      "type": "object",
+      "description": "Named CSS selectors for interactive elements",
+      "additionalProperties": { "type": "string" },
+      "minProperties": 1
+    },
+    "flows": {
+      "type": "object",
+      "description": "Named step sequences for multi-action workflows",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "page_signatures": {
+      "type": "object",
+      "description": "Named lists of selectors that identify a page type",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Pytest bootstrap helpers for flat repository imports.
+
+WHY:
+- The repository is a script-based layout instead of an installed Python package.
+- Pytest can collect tests with `tests/` as the first import root, which would
+  hide modules that live directly at the repository root.
+
+CONSEQUENCES:
+- The repository root is inserted into `sys.path` once during collection.
+- Targeted commands like `pytest tests/test_vision_contract.py -v` work without
+  extra shell prefixes or ad-hoc environment variables.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Resolve the repository root relative to this file so imports stay stable even
+# when pytest is launched from a different working directory.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# Insert the repository root only once to keep import resolution deterministic
+# while avoiding duplicate path entries in long-running test sessions.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_heypiggy_vision_worker.py
+++ b/tests/test_heypiggy_vision_worker.py
@@ -152,12 +152,31 @@ class HeyPiggyWorkerPreflightTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(blocker, "google api key is missing")
 
     def test_collect_opencode_text_includes_json_error_event_messages(self):
-        payload = b'{"type":"error","error":{"message":"Google Generative AI API key is missing","data":{"providerID":"google"}}}\n'
+        payload = b'{"type":"error","error":{"name":"ProviderAuthError","data":{"providerID":"google","message":"Google Generative AI API key is missing"}}}\n'
 
         combined = worker.collect_opencode_text(payload, b"")
 
         self.assertIn("google", combined.lower())
         self.assertIn("api key is missing", combined.lower())
+
+    def test_build_clean_opencode_env_removes_nested_opencode_variables(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENCODE": "1",
+                "OPENCODE_PID": "123",
+                "OPENCODE_ANTIGRAVITY_DEBUG": "1",
+                "PATH": os.environ.get("PATH", ""),
+                "HOME": os.environ.get("HOME", ""),
+            },
+            clear=False,
+        ):
+            env = worker.build_clean_opencode_env()
+
+        self.assertNotIn("OPENCODE", env)
+        self.assertNotIn("OPENCODE_PID", env)
+        self.assertNotIn("OPENCODE_ANTIGRAVITY_DEBUG", env)
+        self.assertIn("PATH", env)
 
 
 class HeyPiggyWorkerClickPipelineTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_heypiggy_vision_worker.py
+++ b/tests/test_heypiggy_vision_worker.py
@@ -31,17 +31,21 @@ class HeyPiggyWorkerPreflightTests(unittest.IsolatedAsyncioTestCase):
         execute_bridge = AsyncMock()
         check_bridge_alive = AsyncMock(return_value=True)
         run_vision_model = AsyncMock(
-            side_effect=AssertionError("vision probe must not run when credentials are missing")
+            side_effect=AssertionError(
+                "vision probe must not run when credentials are missing"
+            )
         )
 
-        with patch.dict(
-            os.environ,
-            {"HEYPIGGY_EMAIL": "", "HEYPIGGY_PASSWORD": ""},
-            clear=False,
-        ), patch.object(worker, "wait_for_extension", AsyncMock(return_value=True)), patch.object(
-            worker, "check_bridge_alive", check_bridge_alive
-        ), patch.object(worker, "run_vision_model", run_vision_model), patch.object(
-            worker, "execute_bridge", execute_bridge
+        with (
+            patch.dict(
+                os.environ,
+                {"HEYPIGGY_EMAIL": "", "HEYPIGGY_PASSWORD": ""},
+                clear=False,
+            ),
+            patch.object(worker, "wait_for_extension", AsyncMock(return_value=True)),
+            patch.object(worker, "check_bridge_alive", check_bridge_alive),
+            patch.object(worker, "run_vision_model", run_vision_model),
+            patch.object(worker, "execute_bridge", execute_bridge),
         ):
             await worker.main()
 
@@ -51,26 +55,30 @@ class HeyPiggyWorkerPreflightTests(unittest.IsolatedAsyncioTestCase):
     async def test_main_stops_before_browser_mutation_when_vision_auth_fails(self):
         execute_bridge = AsyncMock()
 
-        with patch.dict(
-            os.environ,
-            {
-                "HEYPIGGY_EMAIL": "ops@example.com",
-                "HEYPIGGY_PASSWORD": "secret",
-            },
-            clear=False,
-        ), patch.object(worker, "wait_for_extension", AsyncMock(return_value=True)), patch.object(
-            worker, "check_bridge_alive", AsyncMock(return_value=True)
-        ), patch.object(
-            worker,
-            "run_vision_model",
-            AsyncMock(
-                return_value={
-                    "ok": False,
-                    "auth_failure": True,
-                    "error": "401 invalid authentication credentials",
-                }
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "HEYPIGGY_EMAIL": "ops@example.com",
+                    "HEYPIGGY_PASSWORD": "secret",
+                },
+                clear=False,
             ),
-        ), patch.object(worker, "execute_bridge", execute_bridge):
+            patch.object(worker, "wait_for_extension", AsyncMock(return_value=True)),
+            patch.object(worker, "check_bridge_alive", AsyncMock(return_value=True)),
+            patch.object(
+                worker,
+                "run_vision_model",
+                AsyncMock(
+                    return_value={
+                        "ok": False,
+                        "auth_failure": True,
+                        "error": "401 invalid authentication credentials",
+                    }
+                ),
+            ),
+            patch.object(worker, "execute_bridge", execute_bridge),
+        ):
             await worker.main()
 
         execute_bridge.assert_not_awaited()
@@ -78,43 +86,52 @@ class HeyPiggyWorkerPreflightTests(unittest.IsolatedAsyncioTestCase):
     async def test_main_stops_before_browser_mutation_when_vision_health_fails(self):
         execute_bridge = AsyncMock()
 
-        with patch.dict(
-            os.environ,
-            {
-                "HEYPIGGY_EMAIL": "ops@example.com",
-                "HEYPIGGY_PASSWORD": "secret",
-            },
-            clear=False,
-        ), patch.object(worker, "wait_for_extension", AsyncMock(return_value=True)), patch.object(
-            worker, "check_bridge_alive", AsyncMock(return_value=True)
-        ), patch.object(
-            worker,
-            "run_vision_model",
-            AsyncMock(
-                return_value={
-                    "ok": False,
-                    "auth_failure": True,
-                    "error": "vision health check failed",
-                }
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "HEYPIGGY_EMAIL": "ops@example.com",
+                    "HEYPIGGY_PASSWORD": "secret",
+                },
+                clear=False,
             ),
-        ), patch.object(worker, "execute_bridge", execute_bridge):
+            patch.object(worker, "wait_for_extension", AsyncMock(return_value=True)),
+            patch.object(worker, "check_bridge_alive", AsyncMock(return_value=True)),
+            patch.object(
+                worker,
+                "run_vision_model",
+                AsyncMock(
+                    return_value={
+                        "ok": False,
+                        "auth_failure": True,
+                        "error": "vision health check failed",
+                    }
+                ),
+            ),
+            patch.object(worker, "execute_bridge", execute_bridge),
+        ):
             await worker.main()
 
         execute_bridge.assert_not_awaited()
 
     async def test_ask_vision_turns_auth_failure_into_stop(self):
-        with patch.object(worker, "dom_prescan", AsyncMock(return_value="DOM")), patch.object(
-            worker,
-            "run_vision_model",
-            AsyncMock(
-                return_value={
-                    "ok": False,
-                    "auth_failure": True,
-                    "error": "401 invalid authentication credentials",
-                }
+        with (
+            patch.object(worker, "dom_prescan", AsyncMock(return_value="DOM")),
+            patch.object(
+                worker,
+                "run_vision_model",
+                AsyncMock(
+                    return_value={
+                        "ok": False,
+                        "auth_failure": True,
+                        "error": "401 invalid authentication credentials",
+                    }
+                ),
             ),
         ):
-            decision = await worker.ask_vision("/tmp/probe.png", "action", "expected", 1)
+            decision = await worker.ask_vision(
+                "/tmp/probe.png", "action", "expected", 1
+            )
 
         self.assertEqual(decision["verdict"], "STOP")
         self.assertEqual(decision["page_state"], "error")
@@ -127,8 +144,38 @@ class HeyPiggyWorkerPreflightTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(blocker, "provider health check failed")
 
+    def test_detect_vision_auth_failure_treats_missing_api_key_as_blocker(self):
+        blocker = worker.detect_vision_auth_failure(
+            "ProviderAuthError: Google Generative AI API key is missing"
+        )
+
+        self.assertEqual(blocker, "google api key is missing")
+
+    def test_collect_opencode_text_includes_json_error_event_messages(self):
+        payload = b'{"type":"error","error":{"message":"Google Generative AI API key is missing","data":{"providerID":"google"}}}\n'
+
+        combined = worker.collect_opencode_text(payload, b"")
+
+        self.assertIn("google", combined.lower())
+        self.assertIn("api key is missing", combined.lower())
+
 
 class HeyPiggyWorkerClickPipelineTests(unittest.IsolatedAsyncioTestCase):
+    def test_next_action_to_worker_command_converts_accessibility_text_target_into_ref(
+        self,
+    ):
+        next_action = worker.NextAction(
+            type="type",
+            target="textbox @e19",
+            value="ops@example.com",
+        )
+
+        command, params = worker._next_action_to_worker_command(next_action)
+
+        self.assertEqual(command, "type_text")
+        self.assertEqual(params["ref"], "@e19")
+        self.assertEqual(params["text"], "ops@example.com")
+
     async def test_run_click_action_routes_click_ref_through_escalation_pipeline(self):
         gate = DummyGate()
         escalating_click = AsyncMock(return_value=True)

--- a/tests/test_sitepack.py
+++ b/tests/test_sitepack.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the SitepackLoader — validates loading, lookup, and error handling.
+
+WHY THESE TESTS EXIST:
+- The sitepack loader is the single point of truth for ALL CSS selectors used
+  by the browser automation worker.
+- If the loader breaks, the entire worker breaks — no selector can be resolved.
+- These tests cover: valid loading, correct lookup, missing selector errors,
+  schema validation errors, and deterministic page type matching.
+
+CONSEQUENCES:
+- Any regression in the loader is caught before deployment.
+- New sitepack fields or validation rules must be accompanied by new tests.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+# WHY: Ensure the project root is importable regardless of how pytest is invoked
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sitepack_loader import (
+    SelectorNotFoundError,
+    SitepackLoader,
+    SitepackValidationError,
+)
+
+# ---------------------------------------------------------------------------
+# Test Fixtures
+# ---------------------------------------------------------------------------
+
+# WHY: A complete valid sitepack dict that matches the schema.
+# Used as the baseline for all positive tests.
+VALID_SITEPACK = {
+    "site": "heypiggy.com",
+    "version": "1.0.0",
+    "selectors": {
+        "login_email": "input[type='email']",
+        "login_password": "input[type='password']",
+        "login_submit": "button[type='submit']",
+        "consent_next": "#submit-button-cpx",
+    },
+    "flows": {
+        "login": ["navigate_to_login", "fill_email", "fill_password", "click_submit"],
+    },
+    "page_signatures": {
+        "login": ["input[type='email']", "input[type='password']"],
+        "survey_complete": [".thank-you", ".completion"],
+    },
+}
+
+
+def _write_sitepack(data: dict, tmpdir: str) -> str:
+    """Helper: write a sitepack dict to a temporary JSON file.
+
+    WHY: Each test needs an isolated sitepack file on disk so load() can
+    read it. Using tmp_path ensures no cross-test pollution.
+    """
+    path = os.path.join(tmpdir, "pack.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Test Cases
+# ---------------------------------------------------------------------------
+
+
+class TestSitepackLoader:
+    """Test suite for SitepackLoader — covers loading, lookup, and error paths."""
+
+    def test_valid_sitepack_loads_without_error(self, tmp_path):
+        """A valid sitepack JSON should load successfully and expose metadata.
+
+        WHY: This is the happy-path baseline. If this fails, nothing else works.
+        """
+        path = _write_sitepack(VALID_SITEPACK, str(tmp_path))
+        loader = SitepackLoader()
+        loader.load(path)
+
+        # WHY: Verify the loader extracted site and version correctly
+        assert loader.site == "heypiggy.com"
+        assert loader.version == "1.0.0"
+        assert loader.is_loaded is True
+
+    def test_get_selector_returns_correct_value(self, tmp_path):
+        """get_selector() should return the exact CSS selector string for a given name.
+
+        WHY: This is the core contract — the worker calls get_selector('login_email')
+        and must receive exactly "input[type='email']", not something else.
+        """
+        path = _write_sitepack(VALID_SITEPACK, str(tmp_path))
+        loader = SitepackLoader()
+        loader.load(path)
+
+        # WHY: Test multiple selectors to ensure no key confusion
+        assert loader.get_selector("login_email") == "input[type='email']"
+        assert loader.get_selector("consent_next") == "#submit-button-cpx"
+        assert loader.get_selector("login_submit") == "button[type='submit']"
+
+    def test_get_selector_raises_on_unknown_key(self, tmp_path):
+        """Requesting a non-existent selector must raise SelectorNotFoundError.
+
+        WHY: Failing loudly on unknown selectors prevents the worker from
+        silently passing None/empty to a bridge click command.
+        """
+        path = _write_sitepack(VALID_SITEPACK, str(tmp_path))
+        loader = SitepackLoader()
+        loader.load(path)
+
+        with pytest.raises(SelectorNotFoundError):
+            loader.get_selector("nonexistent_selector_that_does_not_exist")
+
+    def test_invalid_sitepack_missing_required_field(self, tmp_path):
+        """A sitepack missing required fields should raise SitepackValidationError.
+
+        WHY: Schema validation at load time prevents the worker from starting
+        with an incomplete sitepack and then crashing mid-survey when a
+        required selector lookup fails.
+        """
+        # WHY: This sitepack is missing 'selectors', 'flows', and 'page_signatures'
+        invalid = {"site": "test.com", "version": "0.1.0"}
+        path = _write_sitepack(invalid, str(tmp_path))
+        loader = SitepackLoader()
+
+        with pytest.raises(SitepackValidationError):
+            loader.load(path)
+
+    def test_match_page_type_identifies_correct_page(self, tmp_path):
+        """match_page_type() should identify the page with the most matching selectors.
+
+        WHY: Deterministic page identification from DOM state is more reliable
+        than parsing free-form vision model text. This test verifies the
+        set-intersection algorithm works correctly for all cases.
+        """
+        path = _write_sitepack(VALID_SITEPACK, str(tmp_path))
+        loader = SitepackLoader()
+        loader.load(path)
+
+        # WHY: Both login selectors present → should match 'login'
+        result = loader.match_page_type(
+            ["input[type='email']", "input[type='password']"]
+        )
+        assert result == "login"
+
+        # WHY: One completion selector present → should match 'survey_complete'
+        result = loader.match_page_type([".thank-you"])
+        assert result == "survey_complete"
+
+        # WHY: No matching selectors → should return 'unknown'
+        result = loader.match_page_type([".random-unrelated-class"])
+        assert result == "unknown"
+
+        # WHY: Empty list → should return 'unknown' (no DOM info available)
+        result = loader.match_page_type([])
+        assert result == "unknown"

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for the typed OpenSIN worker state machine.
+
+WHY THESE TESTS EXIST:
+- The FSM is a safety primitive, so the legal paths must be executable and the
+  illegal paths must fail loudly.
+- Terminal helpers must checkpoint and exit deterministically because the worker
+  depends on them for safe shutdown behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_state_machine import (
+    AgentState,
+    IllegalTransitionError,
+    StepContext,
+    escalate,
+    fail_safe,
+    step_context_advance,
+)
+
+
+# WHY: The production dataclass requires explicit `state` and `step_index`, so
+# this helper keeps the tests concise while still creating realistic contexts.
+def make_context(state: AgentState) -> StepContext:
+    """Create a minimal but realistic FSM context for tests."""
+
+    return StepContext(state=state, step_index=0)
+
+
+# WHY: Terminal helpers always write `checkpoint.json` into the current working
+# directory. Running the tests inside a temp directory keeps the repository clean.
+@pytest.fixture
+def isolated_checkpoint_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run checkpoint-producing tests inside an isolated temporary directory."""
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# WHY: Repeated assertions against the checkpoint format should stay centralized
+# so every terminal-path test validates the same artifact structure consistently.
+def read_checkpoint(tmp_dir: Path) -> dict[str, object]:
+    """Load the checkpoint written by fail-safe or escalation helpers."""
+
+    checkpoint_path = tmp_dir / "checkpoint.json"
+    assert checkpoint_path.exists(), "checkpoint.json was not written"
+    return json.loads(checkpoint_path.read_text(encoding="utf-8"))
+
+
+# WHY: This verifies the worker can move through the earliest bootstrap stages
+# without being blocked by the transition table.
+def test_init_prefight_acquire_session_happy_path() -> None:
+    """INIT -> PREFLIGHT -> ACQUIRE_SESSION should be legal."""
+
+    ctx = make_context(AgentState.INIT)
+    step_context_advance(ctx, AgentState.PREFLIGHT, "preflight start")
+    step_context_advance(ctx, AgentState.ACQUIRE_SESSION, "session acquisition start")
+
+    assert ctx.state == AgentState.ACQUIRE_SESSION
+    assert ctx.step_index == 2
+
+
+# WHY: This covers the middle-of-flow account and task discovery progression the
+# worker needs before it can actually enter a survey.
+def test_authenticate_onboard_discover_select_happy_path() -> None:
+    """AUTHENTICATE -> ONBOARD -> DISCOVER_WORK -> SELECT_TASK should be legal."""
+
+    ctx = make_context(AgentState.AUTHENTICATE)
+    step_context_advance(ctx, AgentState.ONBOARD, "credentials accepted")
+    step_context_advance(ctx, AgentState.DISCOVER_WORK, "onboarding complete")
+    step_context_advance(ctx, AgentState.SELECT_TASK, "tasks visible")
+
+    assert ctx.state == AgentState.SELECT_TASK
+    assert ctx.step_index == 3
+
+
+# WHY: This confirms the worker can progress from active execution to final
+# completion through the required validation and recording phases.
+def test_execute_validate_record_complete_happy_path() -> None:
+    """EXECUTE_TASK_LOOP -> VALIDATE_OUTCOME -> RECORD_RESULT -> COMPLETE should be legal."""
+
+    ctx = make_context(AgentState.EXECUTE_TASK_LOOP)
+    step_context_advance(ctx, AgentState.VALIDATE_OUTCOME, "task loop finished")
+    step_context_advance(ctx, AgentState.RECORD_RESULT, "outcome validated")
+    step_context_advance(ctx, AgentState.COMPLETE, "result persisted")
+
+    assert ctx.state == AgentState.COMPLETE
+    assert ctx.step_index == 3
+
+
+# WHY: The no-progress threshold is a hard safety stop. This test proves that a
+# stuck worker can always transition into FAIL_SAFE and emit a checkpoint.
+def test_any_state_to_fail_safe_when_no_progress_threshold_reached(
+    isolated_checkpoint_dir: Path,
+) -> None:
+    """Any state should be able to fail-safe once no-progress reaches the limit."""
+
+    ctx = make_context(AgentState.EXECUTE_TASK_LOOP)
+    ctx.no_progress_counter = 15
+
+    with pytest.raises(SystemExit) as exit_info:
+        if ctx.no_progress_counter >= 15:
+            fail_safe(ctx, "no progress threshold reached")
+
+    assert exit_info.value.code == 0
+    assert ctx.state == AgentState.FAIL_SAFE
+
+    checkpoint = read_checkpoint(isolated_checkpoint_dir)
+    assert checkpoint["state"] == "FAIL_SAFE"
+    assert checkpoint["reason"] == "no progress threshold reached"
+
+
+# WHY: Retry exhaustion is the canonical escalation case. The test proves that
+# escalation is callable, writes a checkpoint, and exits with a failure code.
+def test_any_state_to_escalate_when_retry_exhaustion_is_detected(
+    isolated_checkpoint_dir: Path,
+) -> None:
+    """Any state should be able to escalate after retry exhaustion."""
+
+    ctx = make_context(AgentState.ASSESS_PAGE)
+
+    with pytest.raises(SystemExit) as exit_info:
+        escalate(ctx, "retry exhaustion simulated", exception=RuntimeError("timeout"))
+
+    assert exit_info.value.code == 1
+    assert ctx.state == AgentState.ESCALATE
+
+    checkpoint = read_checkpoint(isolated_checkpoint_dir)
+    assert checkpoint["state"] == "ESCALATE"
+    assert checkpoint["reason"] == "retry exhaustion simulated"
+    assert "RuntimeError('timeout')" in str(checkpoint["exception"])
+
+
+# WHY: The entire point of the FSM is to reject impossible jumps. This test
+# protects against accidental loosening of the transition table.
+def test_invalid_transition_raises_illegal_transition_error() -> None:
+    """A disallowed state jump should raise IllegalTransitionError."""
+
+    ctx = make_context(AgentState.INIT)
+
+    with pytest.raises(IllegalTransitionError):
+        step_context_advance(ctx, AgentState.COMPLETE, "illegal shortcut")

--- a/tests/test_vision_contract.py
+++ b/tests/test_vision_contract.py
@@ -1,0 +1,153 @@
+"""Pytest coverage for the Vision Gate V2 response contract.
+
+WHY:
+- The new perception layer depends on strict schema parsing and deterministic
+  worker policy enforcement.
+- These tests lock the contract before the worker executes real browser actions.
+
+CONSEQUENCES:
+- Regressions in JSON parsing, fallback parsing, or confidence/blocker policy
+  are caught with a fast targeted pytest run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from vision_contract import VisionVerdict, parse_vision_response
+
+
+# Import the worker module by path so the test remains stable even though the
+# repository is currently a flat script-based layout rather than an installed
+# package.
+MODULE_PATH = Path(__file__).resolve().parents[1] / "heypiggy_vision_worker.py"
+SPEC = importlib.util.spec_from_file_location("heypiggy_vision_worker", MODULE_PATH)
+worker = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(worker)
+
+
+def test_parse_vision_response_accepts_valid_json_contract():
+    """A fully valid JSON payload should map directly into the strict model."""
+
+    raw_text = """
+    {
+      "verdict": "PROCEED",
+      "confidence": 0.91,
+      "page_type": "survey_question",
+      "blocker": null,
+      "next_action": {
+        "type": "click",
+        "target": "selector:#survey-65076903",
+        "value": ""
+      },
+      "dom_hash": "abc123def456",
+      "reasoning": "The survey question is visible and ready for one click."
+    }
+    """
+
+    response = parse_vision_response(raw_text)
+
+    assert response.verdict is VisionVerdict.PROCEED
+    assert response.confidence == 0.91
+    assert response.page_type == "survey_question"
+    assert response.blocker is None
+    assert response.next_action.type == "click"
+    assert response.next_action.target == "selector:#survey-65076903"
+    assert response.dom_hash == "abc123def456"
+
+
+def test_parse_vision_response_falls_back_to_regex_for_malformed_json():
+    """Malformed JSON should still salvage a safe structured response."""
+
+    raw_text = (
+        'verdict: RETRY confidence: 0.73 page_type: survey_list '
+        'reasoning: Modal still covers the survey list next_action: wait target: modal value: loading '
+        'blocker_type: modal blocker_detail: consent banner auto_resolvable: true'
+    )
+
+    response = parse_vision_response(raw_text)
+
+    assert response.verdict is VisionVerdict.RETRY
+    assert response.confidence == 0.73
+    assert response.page_type == "survey_list"
+    assert response.blocker is not None
+    assert response.blocker.type == "modal"
+    assert response.blocker.auto_resolvable is True
+    assert response.next_action.type == "wait"
+
+
+def test_parse_vision_response_returns_retry_for_total_garbage():
+    """Completely unusable model text must degrade into a safe RETRY response."""
+
+    response = parse_vision_response("totally unusable output without any contract fields")
+
+    assert response.verdict is VisionVerdict.RETRY
+    assert response.page_type == "unknown"
+    assert response.next_action.type == "none"
+
+
+def test_low_confidence_policy_forces_retry_even_for_valid_json():
+    """Valid JSON must still fail closed when the model is not confident enough."""
+
+    response = parse_vision_response(
+        """
+        {
+          "verdict": "PROCEED",
+          "confidence": 0.42,
+          "page_type": "survey_question",
+          "blocker": null,
+          "next_action": {"type": "click", "target": "selector:#go", "value": ""},
+          "dom_hash": "hash-low-confidence",
+          "reasoning": "I think the button is probably correct."
+        }
+        """
+    )
+
+    guarded = worker._apply_vision_response_policy(response)
+
+    assert guarded.verdict is VisionVerdict.RETRY
+    assert guarded.next_action.type == "none"
+    assert "Low-confidence" in guarded.reasoning
+
+
+def test_blocker_policy_distinguishes_auto_resolvable_from_escalation():
+    """Worker policy should preserve auto-resolvable blockers and escalate the rest."""
+
+    auto_response = parse_vision_response(
+        """
+        {
+          "verdict": "PROCEED",
+          "confidence": 0.88,
+          "page_type": "survey_list",
+          "blocker": {"type": "modal", "detail": "Cookie banner", "auto_resolvable": true},
+          "next_action": {"type": "click", "target": "selector:#accept-cookies", "value": ""},
+          "dom_hash": "modal-hash",
+          "reasoning": "A dismissible modal blocks the list."
+        }
+        """
+    )
+    manual_response = parse_vision_response(
+        """
+        {
+          "verdict": "PROCEED",
+          "confidence": 0.88,
+          "page_type": "captcha",
+          "blocker": {"type": "captcha", "detail": "Challenge page", "auto_resolvable": false},
+          "next_action": {"type": "none", "target": "", "value": ""},
+          "dom_hash": "captcha-hash",
+          "reasoning": "A captcha blocks progress."
+        }
+        """
+    )
+
+    guarded_auto = worker._apply_vision_response_policy(auto_response)
+    guarded_manual = worker._apply_vision_response_policy(manual_response)
+
+    assert guarded_auto.verdict is VisionVerdict.PROCEED
+    assert guarded_auto.blocker is not None
+    assert guarded_auto.blocker.auto_resolvable is True
+    assert guarded_manual.verdict is VisionVerdict.ESCALATE
+    assert guarded_manual.blocker is not None
+    assert guarded_manual.blocker.auto_resolvable is False

--- a/vision_contract.py
+++ b/vision_contract.py
@@ -1,0 +1,435 @@
+"""Strict schema contract helpers for Vision Gate V2.
+
+This module centralizes the typed contract between the screenshot-based vision
+model output and the worker's decision loop.
+
+WHY:
+- The previous worker logic accepted loosely formatted JSON and then inferred
+  important control-flow fields from ad-hoc string parsing.
+- A single contract module makes the prompt, parser, and tests agree on one
+  canonical shape.
+- The worker can now fail closed with a deterministic RETRY response instead of
+  branching on partially parsed free-form text.
+
+CONSEQUENCES:
+- All vision responses are normalized into the same `VisionResponse` object.
+- Fallback parsing remains tolerant enough for production drift, but the worker
+  always consumes the strict typed structure afterwards.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+# The verdict enum is intentionally string-backed so JSON payloads from the
+# model can be passed through without additional serialization glue.
+class VisionVerdict(str, Enum):
+    """Canonical decision outcomes for the vision gate."""
+
+    PROCEED = "PROCEED"
+    STOP = "STOP"
+    RETRY = "RETRY"
+    ESCALATE = "ESCALATE"
+
+
+@dataclass(slots=True)
+class BlockerInfo:
+    """Structured description of a blocker detected by the vision layer.
+
+    WHY:
+    - Blockers need a dedicated shape so the worker can distinguish between a
+      captcha, a dismissible modal, an auth gate, or a rate-limit banner.
+    - `auto_resolvable` gives the execution loop a deterministic branch instead
+      of guessing whether an obstacle should be handled automatically.
+    """
+
+    type: Literal["captcha", "modal", "auth", "rate_limit"]
+    detail: str
+    auto_resolvable: bool
+
+
+@dataclass(slots=True)
+class NextAction:
+    """Single follow-up action proposed by the vision layer.
+
+    WHY:
+    - The worker should execute one small, explicit action at a time.
+    - `target` and `value` stay generic enough to support click, type, scroll,
+      wait, and no-op behaviors without re-introducing free-form parsing.
+    """
+
+    type: Literal["click", "type", "scroll", "wait", "none"]
+    target: str = ""
+    value: str = ""
+
+
+class VisionResponse(BaseModel):
+    """Validated response envelope returned to the worker loop.
+
+    NOTE:
+    - Pydantic is used for robust field coercion and nested validation.
+    - Range checks that need graceful fallback behavior are enforced inside the
+      parser before model construction so malformed payloads can degrade into a
+      deterministic RETRY response instead of raising out of the loop.
+    """
+
+    verdict: VisionVerdict
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    page_type: str
+    blocker: BlockerInfo | None = None
+    next_action: NextAction
+    dom_hash: str = ""
+    reasoning: str = ""
+
+
+# Action aliases let the parser tolerate legacy outputs from older prompts while
+# still normalizing them into the new generic action schema.
+_ACTION_ALIAS_MAP = {
+    "click": "click",
+    "click_element": "click",
+    "click_ref": "click",
+    "ghost_click": "click",
+    "vision_click": "click",
+    "click_coordinates": "click",
+    "type": "type",
+    "type_text": "type",
+    "scroll": "scroll",
+    "scroll_down": "scroll",
+    "scroll_up": "scroll",
+    "wait": "wait",
+    "none": "none",
+    "navigate": "wait",
+    "keyboard": "click",
+}
+
+
+def _strip_code_fences(raw_text: str) -> str:
+    """Removes optional markdown fences before JSON parsing.
+
+    WHY:
+    - The prompt demands JSON-only output, but real model responses can still
+      occasionally wrap the payload in triple backticks.
+    - Removing the wrapper keeps the parser resilient without relaxing the
+      worker's strict typed contract.
+    """
+
+    text = (raw_text or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"\s*```$", "", text)
+    return text.strip()
+
+
+def _extract_first_json_object(text: str) -> str | None:
+    """Extracts the first balanced JSON object from a noisy response body."""
+
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape = False
+    for index, char in enumerate(text[start:], start=start):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    return None
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Coerces mixed boolean-like values into an actual bool."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "1"}:
+            return True
+        if normalized in {"false", "no", "0"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _coerce_confidence(value: Any, default: float = 0.0) -> float:
+    """Converts confidence to a bounded float.
+
+    WHY:
+    - The contract promises a 0.0-1.0 confidence value.
+    - Bounding the value here avoids model validation errors and keeps the
+      fallback path deterministic.
+    """
+
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, min(1.0, confidence))
+
+
+def _normalize_next_action(candidate: Any) -> NextAction:
+    """Normalizes new-schema or legacy action shapes into `NextAction`."""
+
+    if isinstance(candidate, NextAction):
+        return candidate
+
+    if is_dataclass(candidate):
+        candidate = asdict(candidate)
+
+    if isinstance(candidate, dict):
+        raw_type = str(candidate.get("type", "none") or "none").strip().lower()
+        target = str(candidate.get("target", "") or "")
+        value = str(candidate.get("value", "") or "")
+    else:
+        raw_type = str(candidate or "none").strip().lower()
+        target = ""
+        value = ""
+
+    normalized_type = _ACTION_ALIAS_MAP.get(raw_type, "none")
+    if normalized_type == "click" and not target and isinstance(candidate, dict):
+        target = str(
+            candidate.get("selector")
+            or candidate.get("ref")
+            or candidate.get("description")
+            or candidate.get("coordinates")
+            or ""
+        )
+    if normalized_type == "type" and not value and isinstance(candidate, dict):
+        value = str(candidate.get("text") or candidate.get("value") or "")
+        if not target:
+            target = str(candidate.get("selector") or "")
+    if normalized_type == "scroll" and not value and isinstance(candidate, dict):
+        value = str(candidate.get("direction") or candidate.get("value") or "")
+    return NextAction(type=normalized_type, target=target, value=value)
+
+
+def _normalize_blocker(candidate: Any) -> BlockerInfo | None:
+    """Normalizes blocker payloads into the strict blocker dataclass."""
+
+    if candidate in (None, "", {}):
+        return None
+    if isinstance(candidate, BlockerInfo):
+        return candidate
+    if is_dataclass(candidate):
+        candidate = asdict(candidate)
+    if not isinstance(candidate, dict):
+        return None
+
+    blocker_type = str(candidate.get("type", "") or "").strip().lower()
+    if blocker_type not in {"captcha", "modal", "auth", "rate_limit"}:
+        return None
+
+    return BlockerInfo(
+        type=blocker_type,
+        detail=str(candidate.get("detail", "") or ""),
+        auto_resolvable=_coerce_bool(candidate.get("auto_resolvable"), default=False),
+    )
+
+
+def _candidate_from_regex(raw_text: str) -> dict[str, Any]:
+    """Extracts the most important fields from malformed non-JSON text.
+
+    WHY:
+    - Production model outputs occasionally drift when rate-limited or when the
+      model partially follows the prompt.
+    - Regex extraction salvages enough structure for safe retries without ever
+      pretending the payload was fully valid JSON.
+    """
+
+    text = raw_text or ""
+    verdict_match = re.search(r"\b(PROCEED|STOP|RETRY|ESCALATE)\b", text, re.IGNORECASE)
+    confidence_match = re.search(r"confidence\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)", text, re.IGNORECASE)
+    page_match = re.search(r"page(?:_state|_type)?\s*[:=]\s*[\"']?([a-z_]+)", text, re.IGNORECASE)
+    dom_hash_match = re.search(r"dom_hash\s*[:=]\s*[\"']?([a-f0-9]{6,64})", text, re.IGNORECASE)
+    reasoning_match = re.search(
+        r"(?:reason|reasoning)\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    blocker_match = re.search(
+        r"blocker(?:_type)?\s*[:=]\s*[\"']?(captcha|modal|auth|rate_limit)",
+        text,
+        re.IGNORECASE,
+    )
+    auto_resolvable_match = re.search(
+        r"auto_resolvable\s*[:=]\s*(true|false|yes|no|1|0)",
+        text,
+        re.IGNORECASE,
+    )
+    blocker_detail_match = re.search(
+        r"blocker_detail\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    action_type_match = re.search(
+        r"next_action(?:\.type)?\s*[:=]\s*[\"']?([a-z_]+)",
+        text,
+        re.IGNORECASE,
+    )
+    action_target_match = re.search(
+        r"target\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    action_value_match = re.search(
+        r"value\s*[:=]\s*[\"']?(.+?)(?:[\"']?$|\n(?:\w+\s*[:=]))",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    candidate: dict[str, Any] = {
+        "verdict": (verdict_match.group(1).upper() if verdict_match else "RETRY"),
+        "confidence": (
+            _coerce_confidence(confidence_match.group(1), default=0.0)
+            if confidence_match
+            else 0.0
+        ),
+        "page_type": (page_match.group(1).lower() if page_match else "unknown"),
+        "dom_hash": (dom_hash_match.group(1) if dom_hash_match else ""),
+        "reasoning": (
+            reasoning_match.group(1).strip() if reasoning_match else text.strip()[:300]
+        ),
+        "next_action": {
+            "type": (action_type_match.group(1).lower() if action_type_match else "none"),
+            "target": (action_target_match.group(1).strip() if action_target_match else ""),
+            "value": (action_value_match.group(1).strip() if action_value_match else ""),
+        },
+    }
+
+    if blocker_match:
+        candidate["blocker"] = {
+            "type": blocker_match.group(1).lower(),
+            "detail": (
+                blocker_detail_match.group(1).strip() if blocker_detail_match else ""
+            ),
+            "auto_resolvable": _coerce_bool(
+                auto_resolvable_match.group(1) if auto_resolvable_match else False,
+                default=False,
+            ),
+        }
+
+    return candidate
+
+
+def _normalize_candidate(candidate: dict[str, Any], fallback_reasoning: str) -> VisionResponse:
+    """Builds a strict `VisionResponse` from a partially trusted dictionary."""
+
+    verdict = str(candidate.get("verdict", "RETRY") or "RETRY").upper()
+    if verdict not in VisionVerdict.__members__:
+        verdict = VisionVerdict.RETRY.value
+
+    page_type = str(
+        candidate.get("page_type")
+        or candidate.get("page_state")
+        or "unknown"
+    ).strip().lower()
+    if page_type not in {
+        "login",
+        "survey_list",
+        "survey_question",
+        "survey_complete",
+        "captcha",
+        "unknown",
+    }:
+        page_type = "unknown"
+
+    reasoning = str(
+        candidate.get("reasoning") or candidate.get("reason") or fallback_reasoning
+    ).strip()
+    blocker = _normalize_blocker(candidate.get("blocker"))
+
+    next_action_source = candidate.get("next_action")
+    if next_action_source is None and "next_params" in candidate:
+        next_action_source = {
+            "type": candidate.get("next_action", "none"),
+            **(candidate.get("next_params") or {}),
+        }
+    if next_action_source is None:
+        next_action_source = candidate.get("next_action_type") or "none"
+
+    return VisionResponse(
+        verdict=VisionVerdict(verdict),
+        confidence=_coerce_confidence(candidate.get("confidence"), default=0.0),
+        page_type=page_type,
+        blocker=blocker,
+        next_action=_normalize_next_action(next_action_source),
+        dom_hash=str(candidate.get("dom_hash", "") or ""),
+        reasoning=reasoning,
+    )
+
+
+def parse_vision_response(raw_text: str) -> VisionResponse:
+    """Parses raw model text into the strict vision response contract.
+
+    Parsing strategy:
+    1. Try direct JSON from the raw text.
+    2. If that fails, extract the first balanced JSON object from noisy text.
+    3. If JSON still fails, salvage core fields with regex extraction.
+    4. On total failure, return a safe RETRY response.
+
+    WHY:
+    - The worker must never trust unconstrained model text directly.
+    - The parser must also never crash the main loop over malformed output.
+
+    CONSEQUENCES:
+    - All caller code can operate on one typed object.
+    - The failure path is deterministic and fail-closed.
+    """
+
+    cleaned = _strip_code_fences(raw_text)
+    fallback_reasoning = cleaned[:300] if cleaned else "Vision output missing or unparsable."
+
+    json_candidates = [cleaned]
+    extracted = _extract_first_json_object(cleaned)
+    if extracted and extracted != cleaned:
+        json_candidates.append(extracted)
+
+    for candidate_text in json_candidates:
+        if not candidate_text:
+            continue
+        try:
+            candidate = json.loads(candidate_text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            try:
+                return _normalize_candidate(candidate, fallback_reasoning)
+            except Exception:
+                continue
+
+    try:
+        regex_candidate = _candidate_from_regex(cleaned)
+        return _normalize_candidate(regex_candidate, fallback_reasoning)
+    except Exception:
+        return VisionResponse(
+            verdict=VisionVerdict.RETRY,
+            confidence=0.0,
+            page_type="unknown",
+            blocker=None,
+            next_action=NextAction(type="none", target="", value=""),
+            dom_hash="",
+            reasoning="Vision output missing or unparsable.",
+        )

--- a/vision_prompt.py
+++ b/vision_prompt.py
@@ -1,0 +1,126 @@
+"""Prompt builder for the strict Vision Gate V2 JSON contract.
+
+WHY:
+- The worker must ask the model for one exact machine-readable payload.
+- The prompt now embeds the canonical schema so the model sees the contract
+  inline instead of inferring fields from prose.
+
+CONSEQUENCES:
+- The caller can expect one strict JSON document.
+- The parser can stay simple and fail closed when the model drifts.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def build_vision_prompt(action_desc: str, expected_result: str, dom_snapshot: str) -> str:
+    """Builds the schema-constrained prompt for the screenshot vision call.
+
+    WHY:
+    - The previous free-form prompt allowed commentary, markdown fences, and
+      tool-specific action drift.
+    - Embedding the full JSON schema makes the desired contract explicit and
+      keeps the output aligned with the parser and tests.
+
+    CONSEQUENCES:
+    - The model is instructed to emit JSON only.
+    - The worker can validate the response deterministically.
+    """
+
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "verdict",
+            "confidence",
+            "page_type",
+            "blocker",
+            "next_action",
+            "dom_hash",
+            "reasoning",
+        ],
+        "properties": {
+            "verdict": {
+                "type": "string",
+                "enum": ["PROCEED", "STOP", "RETRY", "ESCALATE"],
+            },
+            "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            "page_type": {
+                "type": "string",
+                "enum": [
+                    "login",
+                    "survey_list",
+                    "survey_question",
+                    "survey_complete",
+                    "captcha",
+                    "unknown",
+                ],
+            },
+            "blocker": {
+                "type": ["object", "null"],
+                "additionalProperties": False,
+                "required": ["type", "detail", "auto_resolvable"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["captcha", "modal", "auth", "rate_limit"],
+                    },
+                    "detail": {"type": "string"},
+                    "auto_resolvable": {"type": "boolean"},
+                },
+            },
+            "next_action": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["type", "target", "value"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["click", "type", "scroll", "wait", "none"],
+                    },
+                    "target": {"type": "string"},
+                    "value": {"type": "string"},
+                },
+            },
+            "dom_hash": {"type": "string"},
+            "reasoning": {"type": "string"},
+        },
+    }
+
+    pretty_schema = json.dumps(schema, ensure_ascii=False, indent=2)
+    dom_text = dom_snapshot.strip() if dom_snapshot.strip() else "<no_dom_snapshot>"
+
+    return f"""You are the OpenSIN Vision Gate controller.
+Analyze the screenshot together with the DOM snapshot and return exactly one JSON object.
+Do not return markdown. Do not wrap the JSON in backticks. Do not include explanations before or after the JSON.
+If you are uncertain, return verdict RETRY instead of guessing.
+
+Action description: {action_desc}
+Expected result: {expected_result}
+
+DOM snapshot:
+{dom_text}
+
+Rules for next_action:
+- type=click: use target to describe the click target. Prefer selector:#css-selector, ref:@e12, text:Visible Label, or coords:123,456.
+- type=type: use target as selector:#css-selector and value as the text to enter. Use <EMAIL> or <PASSWORD> placeholders instead of secrets.
+- type=scroll: use value as down or up.
+- type=wait: use value as a short reason such as loading or rate_limit.
+- type=none: leave target and value as empty strings.
+
+Rules for blockers:
+- blocker=null when no blocker is present.
+- blocker.type=captcha for captcha or challenge pages.
+- blocker.type=modal for consent banners, overlays, cookie banners, or dismissible dialogs.
+- blocker.type=auth for login/session barriers.
+- blocker.type=rate_limit for cooldown banners or retry-later states.
+- auto_resolvable=true only when the worker can realistically dismiss or wait through the blocker automatically.
+
+The DOM hash must reflect the page state you observe. If no hash is visible in the DOM snapshot, return an empty string.
+Reasoning must be concise and factual.
+
+Return JSON that matches this exact schema:
+{pretty_schema}
+"""

--- a/vision_prompt.py
+++ b/vision_prompt.py
@@ -2,8 +2,8 @@
 
 WHY:
 - The worker must ask the model for one exact machine-readable payload.
-- The prompt now embeds the canonical schema so the model sees the contract
-  inline instead of inferring fields from prose.
+- The prompt should stay concise enough that the screenshot+DOM request remains
+  fast and reliable under real browser-run conditions.
 
 CONSEQUENCES:
 - The caller can expect one strict JSON document.
@@ -12,84 +12,23 @@ CONSEQUENCES:
 
 from __future__ import annotations
 
-import json
 
-
-def build_vision_prompt(action_desc: str, expected_result: str, dom_snapshot: str) -> str:
+def build_vision_prompt(
+    action_desc: str, expected_result: str, dom_snapshot: str
+) -> str:
     """Builds the schema-constrained prompt for the screenshot vision call.
 
     WHY:
     - The previous free-form prompt allowed commentary, markdown fences, and
       tool-specific action drift.
-    - Embedding the full JSON schema makes the desired contract explicit and
-      keeps the output aligned with the parser and tests.
+    - A concise explicit contract is more robust in live browser runs than a
+      giant pretty-printed schema dump.
 
     CONSEQUENCES:
     - The model is instructed to emit JSON only.
-    - The worker can validate the response deterministically.
+    - The worker can validate the response deterministically without paying the
+      latency tax of a huge schema blob on every screenshot call.
     """
-
-    schema = {
-        "type": "object",
-        "additionalProperties": False,
-        "required": [
-            "verdict",
-            "confidence",
-            "page_type",
-            "blocker",
-            "next_action",
-            "dom_hash",
-            "reasoning",
-        ],
-        "properties": {
-            "verdict": {
-                "type": "string",
-                "enum": ["PROCEED", "STOP", "RETRY", "ESCALATE"],
-            },
-            "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
-            "page_type": {
-                "type": "string",
-                "enum": [
-                    "login",
-                    "survey_list",
-                    "survey_question",
-                    "survey_complete",
-                    "captcha",
-                    "unknown",
-                ],
-            },
-            "blocker": {
-                "type": ["object", "null"],
-                "additionalProperties": False,
-                "required": ["type", "detail", "auto_resolvable"],
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": ["captcha", "modal", "auth", "rate_limit"],
-                    },
-                    "detail": {"type": "string"},
-                    "auto_resolvable": {"type": "boolean"},
-                },
-            },
-            "next_action": {
-                "type": "object",
-                "additionalProperties": False,
-                "required": ["type", "target", "value"],
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": ["click", "type", "scroll", "wait", "none"],
-                    },
-                    "target": {"type": "string"},
-                    "value": {"type": "string"},
-                },
-            },
-            "dom_hash": {"type": "string"},
-            "reasoning": {"type": "string"},
-        },
-    }
-
-    pretty_schema = json.dumps(schema, ensure_ascii=False, indent=2)
     dom_text = dom_snapshot.strip() if dom_snapshot.strip() else "<no_dom_snapshot>"
 
     return f"""You are the OpenSIN Vision Gate controller.
@@ -103,24 +42,26 @@ Expected result: {expected_result}
 DOM snapshot:
 {dom_text}
 
-Rules for next_action:
-- type=click: use target to describe the click target. Prefer selector:#css-selector, ref:@e12, text:Visible Label, or coords:123,456.
-- type=type: use target as selector:#css-selector and value as the text to enter. Use <EMAIL> or <PASSWORD> placeholders instead of secrets.
-- type=scroll: use value as down or up.
-- type=wait: use value as a short reason such as loading or rate_limit.
-- type=none: leave target and value as empty strings.
+Return JSON with exactly these fields:
+{{
+  "verdict": "PROCEED|STOP|RETRY|ESCALATE",
+  "confidence": 0.0,
+  "page_type": "login|survey_list|survey_question|survey_complete|captcha|unknown",
+  "blocker": null,
+  "next_action": {{
+    "type": "click|type|scroll|wait|none",
+    "target": "selector:#css | ref:@e12 | text:Visible Label | coords:123,456 | ''",
+    "value": "text or direction or ''"
+  }},
+  "dom_hash": "",
+  "reasoning": "short factual reason"
+}}
 
-Rules for blockers:
-- blocker=null when no blocker is present.
-- blocker.type=captcha for captcha or challenge pages.
-- blocker.type=modal for consent banners, overlays, cookie banners, or dismissible dialogs.
-- blocker.type=auth for login/session barriers.
-- blocker.type=rate_limit for cooldown banners or retry-later states.
-- auto_resolvable=true only when the worker can realistically dismiss or wait through the blocker automatically.
-
-The DOM hash must reflect the page state you observe. If no hash is visible in the DOM snapshot, return an empty string.
-Reasoning must be concise and factual.
-
-Return JSON that matches this exact schema:
-{pretty_schema}
+Rules:
+- For type actions, prefer ref:@eNN or selector:#css targets when available.
+- Use <EMAIL> or <PASSWORD> placeholders instead of secrets.
+- blocker.type may only be captcha, modal, auth, or rate_limit.
+- blocker.auto_resolvable=true only when the worker can realistically dismiss or wait through it automatically.
+- If no blocker exists, return blocker as null.
+- If no dom hash is inferable, return an empty string.
 """


### PR DESCRIPTION
## Summary
- integrate PRs #29, #30, and #31 into a single alpha branch
- add runtime hardening for ref-based typing, clean child opencode env, and nested provider error extraction
- keep the full pytest suite green on the integrated worker branch

## Verification
- python3 -m pytest -q  # 26 passed

## Notes
- live HeyPiggy control-plane blocker is now isolated to the local OpenCode binary/plugin loading path, not the worker logic itself
- fixes issue #32 worker-side regression

Closes #32